### PR TITLE
Correctly terminate if no config file can be found

### DIFF
--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -176,6 +176,10 @@ main (int argc, char *argv[])
 	/* get values from the config file */
 	conf = g_key_file_new ();
 	conf_filename = pk_util_get_config_filename ();
+	if (conf_filename == NULL) {
+		g_print ("Failed to find a config file.\n");
+		goto out;
+	}
 	ret = g_key_file_load_from_file (conf, conf_filename,
 					 G_KEY_FILE_NONE, &error);
 	if (!ret) {


### PR DESCRIPTION
If no config file is found pk_util_get_config_filename returns
NULL, which then gets passed into g_key_file_load_from_file
which if it receives a NULL value as a filename it will return
FALSE, and not set error, causing a segfault when trying to
print error->message.

I'm not sure if you take pull requests here, but I figured I'd give it a shot.
