### PR TITLE
backends/hif: Move hif_source_is_supported() here

### DIFF
--- a/backends/hif/pk-backend-hif.c
+++ b/backends/hif/pk-backend-hif.c
@@ -1089,6 +1089,35 @@ pk_backend_get_updates (PkBackend *backend,
 	pk_backend_job_thread_create (job, pk_backend_search_thread, NULL, NULL);
 }
 
+/* Obviously hardcoded and Fedora specific.  Colin Walters thinks this
+ * concept should be based on user's trust of a GPG key or something
+ * more flexible.
+ */
+static gboolean
+source_is_supported (HifSource *source)
+{
+	const char *id = hif_source_get_id (source);
+	guint i;
+	const gchar *valid[] = { "fedora",
+				 "fedora-debuginfo",
+				 "fedora-source",
+				 "rawhide",
+				 "rawhide-debuginfo",
+				 "rawhide-source",
+				 "updates",
+				 "updates-debuginfo",
+				 "updates-source",
+				 "updates-testing",
+				 "updates-testing-debuginfo",
+				 "updates-testing-source",
+				 NULL };
+	for (i = 0; valid[i] != NULL; i++) {
+		if (g_strcmp0 (id, valid[i]) == 0)
+			return TRUE;
+	}
+	return FALSE;
+}
+
 /**
  * pk_backend_source_filter:
  */
@@ -1121,10 +1150,10 @@ pk_backend_source_filter (HifSource *src, PkBitfield filters)
 
 	/* supported and ~supported == core */
 	if (pk_bitfield_contain (filters, PK_FILTER_ENUM_SUPPORTED) &&
-	    !hif_source_is_supported (src))
+	    !source_is_supported (src))
 		return FALSE;
 	if (pk_bitfield_contain (filters, PK_FILTER_ENUM_NOT_SUPPORTED) &&
-	    hif_source_is_supported (src))
+	    source_is_supported (src))
 		return FALSE;
 
 	/* not filtered */


### PR DESCRIPTION
I think this concept should be based on user's trust of a GPG key or
something more flexible.  Moving it to PackageKit is cleaner as it's
PK that has the concept of "supported", not libhif.