### PR TITLE
alpm: bump required libalpm version number and fix version define

### DIFF
--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -29,16 +29,11 @@
  * versioning. A patch has been proposed, though:
  * https://lists.archlinux.org/pipermail/pacman-dev/2014-December/019759.html
  *
- * If ALPM_VERSION_NUMBER is *not* defined we test for
- * ALPM_EVENT_PACKAGE_OPERATION_START, which is libalpm >= 9.0.0 only and
- * define ALPM_VERSION_NUMBER on our own. */
+ * There's no usable define in alpm.h in libalpm up to and including 9.0.0.
+ * configure makes sure we have 9.0.0 at least, so define that. */
 
 #ifndef ALPM_VERSION_NUMBER
-#	ifndef ALPM_EVENT_PACKAGE_OPERATION_START
-#		define	ALPM_VERSION_NUMBER	0x080200
-#	else
-#		define	ALPM_VERSION_NUMBER	0x090000
-#	endif
+#	define	ALPM_VERSION_NUMBER	0x090000
 #endif
 
 typedef struct {

--- a/configure.ac
+++ b/configure.ac
@@ -506,7 +506,7 @@ if test x$enable_aptcc = xyes; then
 fi
 
 if test x$enable_alpm = xyes; then
-	PKG_CHECK_MODULES(ALPM, libalpm >= 8.2.0)
+	PKG_CHECK_MODULES(ALPM, libalpm >= 9.0.0)
 fi
 
 if test x$enable_poldek = xyes; then


### PR DESCRIPTION
ALPM_EVENT_PACKAGE_OPERATION_START is enumeration, not define. So we can
not use that in preprocessor.

Bump required libalpm version to 9.0.0 (pacman 4.2.0) and define that.