### PR TITLE
alpm: reintroduce pacman < 4.2 compatibility

### DIFF
--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -21,25 +21,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include "../../config.h"
 #include <alpm.h>
 #include <gio/gio.h>
 #include <pk-backend.h>
-
-/* libalpm up to and including version 9.0.0 (pacman 4.2.0) lack proper
- * versioning. A patch has been proposed, though:
- * https://lists.archlinux.org/pipermail/pacman-dev/2014-December/019759.html
- *
- * If ALPM_VERSION_NUMBER is *not* defined we test for
- * ALPM_EVENT_PACKAGE_OPERATION_START, which is libalpm >= 9.0.0 only and
- * define ALPM_VERSION_NUMBER on our own. */
-
-#ifndef ALPM_VERSION_NUMBER
-#	ifndef ALPM_EVENT_PACKAGE_OPERATION_START
-#		define	ALPM_VERSION_NUMBER	0x080200
-#	else
-#		define	ALPM_VERSION_NUMBER	0x090000
-#	endif
-#endif
 
 typedef struct {
 	gsize		environment_initialized;

--- a/configure.ac
+++ b/configure.ac
@@ -507,6 +507,17 @@ fi
 
 if test x$enable_alpm = xyes; then
 	PKG_CHECK_MODULES(ALPM, libalpm >= 8.2.0)
+
+	# libalpm up to and including version 9.0.0 (pacman 4.2.0) lack proper
+	# versioning. A patch has been proposed, though:
+	# https://lists.archlinux.org/pipermail/pacman-dev/2014-December/019759.html
+
+	PKG_CHECK_EXISTS(libalpm >= 9.0.0, [ HAVE_ALPM_VERSION_9="yes" ], [ HAVE_ALPM_VERSION_9="no" ])
+	if test "x$HAVE_ALPM_VERSION_9" = "xyes"; then
+		AC_DEFINE(ALPM_VERSION_NUMBER, 0x090000, [libalpm version number])
+	else
+		AC_DEFINE(ALPM_VERSION_NUMBER, 0x080200, [libalpm version number])
+	fi
 fi
 
 if test x$enable_poldek = xyes; then


### PR DESCRIPTION
Try to make it work with libalpm 8.2.0 and 9.0.0.