### PR TITLE
alpm: honor simulation when installing packages

### DIFF
--- a/backends/alpm/pk-alpm-sync.c
+++ b/backends/alpm/pk-alpm-sync.c
@@ -144,7 +144,13 @@ pk_backend_install_packages_thread (PkBackendJob *job, GVariant* params, gpointe
 	if (pk_alpm_transaction_initialize (job, 0, NULL, &error) &&
 	    pk_alpm_transaction_sync_targets (job, package_ids, &error) &&
 	    pk_alpm_transaction_simulate (job, &error)) {
-		pk_alpm_transaction_commit (job, &error);
+
+		if (pk_bitfield_contain (transaction_flags, PK_TRANSACTION_FLAG_ENUM_SIMULATE)) { /* simulation */
+			pk_alpm_transaction_packages (job);
+		}
+		else {/* real installation */
+			pk_alpm_transaction_commit (job, &error);
+		}
 	}
 
 	pk_alpm_transaction_end (job, (error == NULL) ? &error : NULL);


### PR DESCRIPTION
Fix #36 

Before this fix I was asked to proceed or not with installation. With this code, I'm no longer asked for confirmation. I think it was a question from libalpm and now with the right workflow there is no more question.