### PR TITLE
alpm: fix remove package

### DIFF
--- a/backends/alpm/pk-alpm-remove.c
+++ b/backends/alpm/pk-alpm-remove.c
@@ -101,7 +101,12 @@ pk_backend_remove_packages_thread (PkBackendJob *job, GVariant* params, gpointer
 	if (pk_alpm_transaction_initialize (job, flags, NULL, &error) &&
 	    pk_alpm_transaction_remove_targets (job, package_ids, &error) &&
 	    pk_alpm_transaction_remove_simulate (job, &error)) {
-		pk_alpm_transaction_commit (job, &error);
+		if (pk_bitfield_contain (transaction_flags, PK_TRANSACTION_FLAG_ENUM_SIMULATE)) { /* simulation */
+			pk_alpm_transaction_packages (job);
+		}
+		else {
+			pk_alpm_transaction_commit (job, &error);
+		}
 	}
 
 	pk_alpm_transaction_finish (job, error);

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -642,7 +642,7 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 					pk_alpm_transaction_add_start (job, e->newpkg);
 					break;
 				case ALPM_PACKAGE_REMOVE:
-					pk_alpm_transaction_remove_start (job, e->newpkg);
+					pk_alpm_transaction_remove_start (job, e->oldpkg);
 					break;
 				case ALPM_PACKAGE_UPGRADE:
 				case ALPM_PACKAGE_DOWNGRADE:
@@ -660,7 +660,7 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 					pk_alpm_transaction_add_done (job, e->newpkg);
 					break;
 				case ALPM_PACKAGE_REMOVE:
-					pk_alpm_transaction_remove_done (job, e->newpkg);
+					pk_alpm_transaction_remove_done (job, e->oldpkg);
 					break;
 				case ALPM_PACKAGE_UPGRADE:
 					pk_alpm_transaction_upgrade_done (job, e->newpkg, e->oldpkg, 1);


### PR DESCRIPTION
This PR is to fix #39.

I fixed a bad event usage in case of package removal but I still have some strange behavior.

If I remove the ncdu package with `./pkcon remove ncdu` I get the following output :
```
Resolving                     [=========================]         
Testing changes               [=========================]         
Finished                      [=========================]         
Removing                      [=========================]         
Waiting for authentication    [=========================]         
Finished                      [=========================]         
Fatal error: ncdu: could not find or read package
```

On the daemon side I have :
```
./run-pk.sh alpm
packagekitd: no process found
22:58:04	PackageKit          Verbose debugging enabled (on console 1)
22:58:04	PackageKit          daemon shutdown set to 0 seconds
22:58:04	PackageKit          clearing download cache at /home/fabien/Projets/jhbuild/install/var/cache/PackageKit/downloads
22:58:04	PackageKit          destination wlp4s0 is valid
22:58:04	PackageKit          setting config file watch on /etc/PackageKit/PackageKit.conf
22:58:04	PackageKit          Trying to load : alpm
22:58:04	PackageKit          dlopening '/home/fabien/Projets/jhbuild/install/lib/packagekit-backend/libpk_backend_alpm.so'
22:58:04	PackageKit          trying to open database '/home/fabien/Projets/jhbuild/install/var/lib/PackageKit/transactions.db'
22:58:04	PackageKit          job count is now at 0
22:58:04	PackageKit          is_default: 0
22:58:04	PackageKit          not default, skipping
22:58:04	PackageKit          is_default: 1
22:58:04	PackageKit          network state is wifi
22:58:04	PackageKit          PkEngine: acquired name: org.freedesktop.PackageKit
22:58:18	PackageKit          CreateTransaction method called
22:58:18	PackageKit          job count now 1
22:58:18	PackageKit          trying to open database '/home/fabien/Projets/jhbuild/install/var/lib/PackageKit/transactions.db'
22:58:18	PackageKit          job count is now at 0
22:58:18	PackageKit          transaction now new
22:58:18	PackageKit          setting sender to :1.92
22:58:18	PackageKit          adding transaction 0x7fac5b868150
22:58:18	PackageKit          sending object path: '/1_dabbebad'
22:58:18	PackageKit          notify::connected
22:58:18	PackageKit          SetHints method called: locale=C, background=false, interactive=true, cache-age=4294967295
22:58:18	PackageKit          cache-age changed to -1
22:58:18	PackageKit          Resolve method called: 4, ncdu
22:58:18	PackageKit          transaction now ready
22:58:18	PackageKit          changing transaction to exclusive mode
22:58:18	PackageKit          1 transactions in list, 1 committed but not finished
22:58:18	PackageKit          transaction now running
22:58:18	PackageKit          failed to set the session state (non-fatal): failed to get the proxy from the database
22:58:18	PackageKit          setting role for /1_dabbebad to resolve
22:58:18	PackageKit          emit package installed, ncdu;1.10-1;x86_64;installed, Disk usage analyzer with an ncurses interface
22:58:18	PackageKit          backend was running for 3 ms
22:58:18	PackageKit          emitting finished 'success', 3
22:58:18	PackageKit          transaction now finished
22:58:18	PackageKit          1 transactions in list, 0 committed but not finished
22:58:18	PackageKit          CreateTransaction method called
22:58:18	PackageKit          job count now 2
22:58:18	PackageKit          trying to open database '/home/fabien/Projets/jhbuild/install/var/lib/PackageKit/transactions.db'
22:58:18	PackageKit          job count is now at 0
22:58:18	PackageKit          transaction now new
22:58:18	PackageKit          setting sender to :1.92
22:58:18	PackageKit          adding transaction 0x7fac5b8682c0
22:58:18	PackageKit          sending object path: '/2_aacceabc'
22:58:18	PackageKit          SetHints method called: locale=C, background=false, interactive=true, cache-age=4294967295
22:58:18	PackageKit          cache-age changed to -1
22:58:18	PackageKit          RemovePackages method called: ncdu;1.10-1;x86_64;installed, 1, 0 (transaction_flags: simulate)
22:58:18	PackageKit          changing transaction to exclusive mode
22:58:18	PackageKit          No authentication required
22:58:18	PackageKit          transaction now ready
22:58:18	PackageKit          changing transaction to exclusive mode
22:58:18	PackageKit          2 transactions in list, 1 committed but not finished
22:58:18	PackageKit          transaction now running
22:58:18	PackageKit          failed to set the session state (non-fatal): failed to get the proxy from the database
22:58:18	PackageKit          setting role for /2_aacceabc to remove-packages
22:58:18	PackageKit          emitting allow-cancel 0
22:58:18	PackageKit          opened logind fd 16
22:58:18	PackageKit          2 transactions in list, 1 committed but not finished
22:58:18	PackageKit          emit package removing, ncdu;1.10-1;x86_64;installed, Disk usage analyzer with an ncurses interface
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 0
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 10
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 20
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 30
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 40
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 50
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 60
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 70
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 80
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 90
22:58:18	PackageKit          emitting item-progress ncdu, unknown: 100
22:58:18	PackageKit          emit package finished, ncdu;1.10-1;x86_64;installed, Disk usage analyzer with an ncurses interface
22:58:18	PackageKit          emitting allow-cancel 1
22:58:18	PackageKit          closed logind fd 16
22:58:18	PackageKit          2 transactions in list, 1 committed but not finished
22:58:18	PackageKit          backend was running for 229 ms
22:58:18	PackageKit          emitting finished 'success', 229
22:58:18	PackageKit          transaction now finished
22:58:18	PackageKit          2 transactions in list, 0 committed but not finished
22:58:18	PackageKit          CreateTransaction method called
22:58:18	PackageKit          job count now 3
22:58:18	PackageKit          trying to open database '/home/fabien/Projets/jhbuild/install/var/lib/PackageKit/transactions.db'
22:58:18	PackageKit          job count is now at 0
22:58:18	PackageKit          transaction now new
22:58:18	PackageKit          setting sender to :1.92
22:58:18	PackageKit          adding transaction 0x7fac5b868430
22:58:18	PackageKit          sending object path: '/3_eaedeeed'
22:58:18	PackageKit          SetHints method called: locale=C, background=false, interactive=true, cache-age=4294967295
22:58:18	PackageKit          cache-age changed to -1
22:58:18	PackageKit          RemovePackages method called: ncdu;1.10-1;x86_64;installed, 1, 0 (transaction_flags: none)
22:58:18	PackageKit          changing transaction to exclusive mode
22:58:18	PackageKit          transaction now waiting-for-auth
22:58:18	PackageKit          authorizing action org.freedesktop.packagekit.package-remove
22:58:21	PackageKit          transaction now ready
22:58:21	PackageKit          changing transaction to exclusive mode
22:58:21	PackageKit          3 transactions in list, 1 committed but not finished
22:58:21	PackageKit          transaction now running
22:58:21	PackageKit          failed to set the session state (non-fatal): failed to get the proxy from the database
22:58:21	PackageKit          setting role for /3_eaedeeed to remove-packages
22:58:21	PackageKit          emitting error-code package-not-found, 'ncdu: could not find or read package'
22:58:21	PackageKit          backend was running for 1 ms
22:58:21	PackageKit          emitting finished 'failed', 1
22:58:21	PackageKit          transaction now finished
22:58:21	PackageKit          3 transactions in list, 0 committed but not finished
22:58:23	PackageKit          transaction /1_dabbebad completed, removing
22:58:23	PackageKit          emitting destroy /1_dabbebad
22:58:23	PackageKit          transaction /2_aacceabc completed, removing
22:58:23	PackageKit          emitting destroy /2_aacceabc
22:58:26	PackageKit          transaction /3_eaedeeed completed, removing
22:58:26	PackageKit          emitting destroy /3_eaedeeed
```

I don't know (yet) what happens here but I will do some investigation. 