### PR TITLE
alpm: track local db changes and invalidate cache

### DIFF
--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -1011,6 +1011,7 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
 	alpm_list_t *data = NULL;
 	_cleanup_free_ gchar *prefix = NULL;
+	gint commit_result;
 
 	if (pk_backend_job_is_cancelled (job))
 		return TRUE;
@@ -1018,7 +1019,10 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 	pk_backend_job_set_allow_cancel (job, FALSE);
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_RUNNING);
 
-	if (alpm_trans_commit (priv->alpm, &data) >= 0)
+	pk_backend_transaction_inhibit_start (backend);
+	commit_result = alpm_trans_commit (priv->alpm, &data);
+	pk_backend_transaction_inhibit_end (backend);
+	if (commit_result >= 0)
 		return TRUE;
 
 	switch (alpm_errno (priv->alpm)) {

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -47,6 +47,7 @@ typedef struct {
 	alpm_list_t	*syncfirsts;
 	alpm_list_t	*holdpkgs;
 	alpm_handle_t	*alpm;
+	GFileMonitor    *monitor;
 } PkBackendAlpmPrivate;
 
 void		 pk_alpm_run		(PkBackendJob *job, PkStatusEnum status,


### PR DESCRIPTION
This PR is about fixing #15 . Here I'm monitoring /var/lib/pacman/local for changes.

As I asked in #15, is this what I must do here or I should also watch repos synced dbs or only the synced db or something else ?

I also have an other question about `pk_backend_transaction_inhibit_start` are those required and in which case I should call it ? I looked at hif calls but I don't have enought knowledge of the hif backend to understand the behavior.

About the code, I think I'm doing things right with threads and memory. But any reviews are welcome.

cc @hughsie @aleixpol @kalev 