### PR TITLE
Track pacman changes

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -796,7 +796,7 @@ pk_alpm_siglevel_cross (alpm_siglevel_t base, const alpm_list_t *list, GError **
 }
 
 static gboolean
-pk_alpm_config_configure_repos (PkAlpmConfig *config,
+pk_alpm_config_configure_repos (PkBackend *backend, PkAlpmConfig *config,
 				   alpm_handle_t *handle, GError **error)
 {
 	alpm_siglevel_t base, local, remote;
@@ -834,7 +834,7 @@ pk_alpm_config_configure_repos (PkAlpmConfig *config,
 		level = pk_alpm_siglevel_parse (base, repo->siglevels, error);
 		if (level == ALPM_SIG_USE_DEFAULT)
 			return FALSE;
-		pk_alpm_add_database (repo->name, repo->servers, level);
+		pk_alpm_add_database (backend, repo->name, repo->servers, level);
 	}
 
 	return TRUE;
@@ -936,7 +936,7 @@ out:
 }
 
 static alpm_handle_t *
-pk_alpm_config_configure_alpm (PkAlpmConfig *config, GError **error)
+pk_alpm_config_configure_alpm (PkBackend *backend, PkAlpmConfig *config, GError **error)
 {
 	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (config->backend);
 	alpm_handle_t *handle;
@@ -984,7 +984,7 @@ pk_alpm_config_configure_alpm (PkAlpmConfig *config, GError **error)
 	alpm_option_set_noupgrades (handle, config->noupgrades);
 	config->noupgrades = NULL;
 
-	pk_alpm_config_configure_repos (config, handle, error);
+	pk_alpm_config_configure_repos (backend, config, handle, error);
 
 	return handle;
 }
@@ -1003,7 +1003,7 @@ pk_alpm_configure (PkBackend *backend, const gchar *filename, GError **error)
 	pk_alpm_config_enter_section (config, "options");
 
 	if (pk_alpm_config_parse (config, filename, NULL, &e))
-		handle = pk_alpm_config_configure_alpm (config, &e);
+		handle = pk_alpm_config_configure_alpm (backend, config, &e);
 
 	pk_alpm_config_free (config);
 	if (e != NULL) {

--- a/backends/alpm/pk-alpm-databases.c
+++ b/backends/alpm/pk-alpm-databases.c
@@ -33,7 +33,6 @@ typedef struct
 	alpm_siglevel_t level;
 } PkBackendRepo;
 
-static GHashTable *disabled = NULL;
 static alpm_list_t *configured = NULL;
 
 static GHashTable *
@@ -172,23 +171,26 @@ pk_alpm_add_database (const gchar *name, alpm_list_t *servers,
 gboolean
 pk_alpm_disable_signatures (PkBackend *backend, GError **error)
 {
-	return pk_alpm_disabled_repos_configure (backend, disabled, FALSE, error);
+	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
+	return pk_alpm_disabled_repos_configure (backend, priv->disabled_repos, FALSE, error);
 }
 
 gboolean
 pk_alpm_enable_signatures (PkBackend *backend, GError **error)
 {
-	return pk_alpm_disabled_repos_configure (backend, disabled, TRUE, error);
+	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
+	return pk_alpm_disabled_repos_configure (backend, priv->disabled_repos, TRUE, error);
 }
 
 gboolean
 pk_alpm_initialize_databases (PkBackend *backend, GError **error)
 {
-	disabled = pk_alpm_disabled_repos_new (error);
-	if (disabled == NULL)
+	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
+	priv->disabled_repos = pk_alpm_disabled_repos_new (error);
+	if (priv->disabled_repos == NULL)
 		return FALSE;
 
-	if (!pk_alpm_disabled_repos_configure (backend, disabled, TRUE, error))
+	if (!pk_alpm_disabled_repos_configure (backend, priv->disabled_repos, TRUE, error))
 		return FALSE;
 
 	return TRUE;
@@ -197,10 +199,11 @@ pk_alpm_initialize_databases (PkBackend *backend, GError **error)
 void
 pk_alpm_destroy_databases (PkBackend *backend)
 {
+	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
 	alpm_list_t *i;
 
-	if (disabled != NULL)
-		pk_alpm_disabled_repos_free (disabled);
+	if (priv->disabled_repos != NULL)
+		pk_alpm_disabled_repos_free (priv->disabled_repos);
 
 	for (i = configured; i != NULL; i = i->next) {
 		PkBackendRepo *repo = (PkBackendRepo *) i->data;
@@ -229,7 +232,7 @@ pk_backend_get_repo_list_thread (PkBackendJob *job, GVariant *params, gpointer d
 	GHashTableIter iter;
 	gpointer key, value;
 
-	g_return_if_fail (disabled != NULL);
+	g_return_if_fail (priv->disabled_repos != NULL);
 
 	/* emit enabled repos */
 	for (i = alpm_get_syncdbs (priv->alpm); i != NULL; i = i->next) {
@@ -241,7 +244,7 @@ pk_backend_get_repo_list_thread (PkBackendJob *job, GVariant *params, gpointer d
 	}
 
 	/* emit disabled repos */
-	g_hash_table_iter_init (&iter, disabled);
+	g_hash_table_iter_init (&iter, priv->disabled_repos);
 	while (g_hash_table_iter_next (&iter, &key, &value)) {
 		const gchar *repo = (const gchar *) key;
 		if (pk_backend_job_is_cancelled (job))
@@ -264,15 +267,16 @@ pk_backend_repo_enable_thread (PkBackendJob *job, GVariant *params, gpointer dat
 	const gchar *repo;
 	gboolean enabled;
 	PkBackend *backend = pk_backend_job_get_backend (job);
+	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
 	_cleanup_error_free_ GError *error = NULL;
 
-	g_return_if_fail (disabled != NULL);
+	g_return_if_fail (priv->disabled_repos != NULL);
 
 	g_variant_get (params, "(&sb)", &repo, &enabled);
 
-	if (g_hash_table_remove (disabled, repo)) {
+	if (g_hash_table_remove (priv->disabled_repos, repo)) {
 		/* reload configuration to preserve ordering */
-		if (pk_alpm_disabled_repos_configure (backend, disabled, TRUE, &error)) {
+		if (pk_alpm_disabled_repos_configure (backend, priv->disabled_repos, TRUE, &error)) {
 			pk_backend_repo_list_changed (backend);
 		}
 	} else {
@@ -311,7 +315,7 @@ pk_backend_repo_disable_thread (PkBackendJob *job, GVariant *params, gpointer da
 					     "[%s]: %s", repo,
 					     alpm_strerror (errno));
 			} else {
-				g_hash_table_insert (disabled, g_strdup (repo),
+				g_hash_table_insert (priv->disabled_repos, g_strdup (repo),
 						     GINT_TO_POINTER (1));
 			}
 			break;

--- a/backends/alpm/pk-alpm-databases.h
+++ b/backends/alpm/pk-alpm-databases.h
@@ -24,7 +24,8 @@
 #include <alpm.h>
 #include <pk-backend.h>
 
-void		 pk_alpm_add_database			(const gchar *name,
+void		 pk_alpm_add_database			(PkBackend *backend,
+					                 const gchar *name,
 							 alpm_list_t *servers,
 							 alpm_siglevel_t level);
 

--- a/backends/alpm/pk-alpm-packages.c
+++ b/backends/alpm/pk-alpm-packages.c
@@ -149,8 +149,6 @@ pk_backend_resolve_name (PkBackendJob *job, const gchar *name, PkBitfield filter
 	alpm_pkg_t *pkg;
 	int code;
 
-	gboolean skip_local, skip_remote;
-
 	g_return_val_if_fail (name != NULL, FALSE);
 
 	/* lookup into the local db */

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -957,10 +957,11 @@ pk_alpm_transaction_packages (PkBackendJob *job)
 
 	/* emit packages that would have been installed */
 	for (i = alpm_trans_get_add (priv->alpm); i != NULL; i = i->next) {
+		const gchar *name;
 		if (pk_backend_job_is_cancelled (job))
 			break;
 
-		const gchar *name = alpm_pkg_get_name (i->data);
+		name = alpm_pkg_get_name (i->data);
 
 		if (alpm_db_get_pkg (priv->localdb, name) != NULL) {
 			info = PK_INFO_ENUM_UPDATING;

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -48,6 +48,7 @@ typedef struct {
 	alpm_list_t	*holdpkgs;
 	alpm_handle_t	*alpm;
 	GFileMonitor    *monitor;
+	GHashTable      *disabled_repos; /* list of disabled repos */
 } PkBackendAlpmPrivate;
 
 void		 pk_alpm_run		(PkBackendJob *job, PkStatusEnum status,

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -50,6 +50,7 @@ typedef struct {
 	GFileMonitor    *monitor;
 	GHashTable      *disabled_repos; /* list of disabled repos */
 	alpm_list_t     *configured_repos; /* list of configured repos */
+	gboolean	localdb_changed;
 } PkBackendAlpmPrivate;
 
 void		 pk_alpm_run		(PkBackendJob *job, PkStatusEnum status,

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -49,6 +49,7 @@ typedef struct {
 	alpm_handle_t	*alpm;
 	GFileMonitor    *monitor;
 	GHashTable      *disabled_repos; /* list of disabled repos */
+	alpm_list_t     *configured_repos; /* list of configured repos */
 } PkBackendAlpmPrivate;
 
 void		 pk_alpm_run		(PkBackendJob *job, PkStatusEnum status,


### PR DESCRIPTION
When localdb is modified outside packagekit, we need to do a reload of localdb contents to drop internal caches. To avoid any race condition, caches are dropped on next transaction.