### PR TITLE
Make "reboot" the default action for no action file

### DIFF
--- a/lib/packagekit-glib2/pk-offline.c
+++ b/lib/packagekit-glib2/pk-offline.c
@@ -240,7 +240,7 @@ pk_offline_get_action (GError **error)
 	/* is the trigger set? */
 	if (!g_file_test (PK_OFFLINE_TRIGGER_FILENAME, G_FILE_TEST_EXISTS) ||
 	    !g_file_test (PK_OFFLINE_ACTION_FILENAME, G_FILE_TEST_EXISTS))
-		return PK_OFFLINE_ACTION_UNSET;
+		return PK_OFFLINE_ACTION_REBOOT;
 
 	/* read data file */
 	if (!g_file_get_contents (PK_OFFLINE_ACTION_FILENAME,

--- a/lib/packagekit-glib2/pk-test-private.c
+++ b/lib/packagekit-glib2/pk-test-private.c
@@ -652,7 +652,7 @@ pk_test_offline_func (void)
 	/* test no action set */
 	action = pk_offline_get_action (&error);
 	g_assert_no_error (error);
-	g_assert_cmpint (action, ==, PK_OFFLINE_ACTION_UNSET);
+	g_assert_cmpint (action, ==, PK_OFFLINE_ACTION_REBOOT);
 
 	/* try to trigger without the fake updates set */
 	ret = pk_offline_auth_trigger (PK_OFFLINE_ACTION_REBOOT, &error);


### PR DESCRIPTION
This will allow the user to specify systemd.unit=system-update.target
on the kernel boot line to initiate pending updates.