### PR TITLE
zsh support for command-not-found

### DIFF
--- a/contrib/command-not-found/PackageKit.sh.in
+++ b/contrib/command-not-found/PackageKit.sh.in
@@ -24,7 +24,8 @@ command_not_found_handle () {
 		@LIBEXECDIR@/pk-command-not-found "$@"
 		retval=$?
 	else
-		echo "bash: $1: command not found"
+		local shell=`basename "$SHELL"`
+		echo "$shell: $1: command not found"
 	fi
 
 	# return success or failure

--- a/contrib/command-not-found/PackageKit.sh.in
+++ b/contrib/command-not-found/PackageKit.sh.in
@@ -31,3 +31,8 @@ command_not_found_handle () {
 	return $retval
 }
 
+if [ -n "$ZSH_VERSION" ]; then
+	command_not_found_handler () {
+		command_not_found_handle "$@"
+	}
+fi

--- a/contrib/command-not-found/pk-command-not-found.c
+++ b/contrib/command-not-found/pk-command-not-found.c
@@ -738,6 +738,9 @@ main (int argc, char *argv[])
 	const gchar *possible;
 	gchar **parts;
 	guint retval = EXIT_COMMAND_NOT_FOUND;
+	const gchar *shell = "bash";
+	const gchar *env_shell;
+	_cleanup_free_ gchar *shell_to_free = NULL;
 	_cleanup_ptrarray_unref_ GPtrArray *array = NULL;
 	_cleanup_strv_free_ gchar **package_ids = NULL;
 
@@ -781,10 +784,14 @@ main (int argc, char *argv[])
 	if (argv[1][0] == '.')
 		goto out;
 
+	env_shell = g_getenv ("SHELL");
+	if (env_shell != NULL)
+		shell = shell_to_free = g_path_get_basename (env_shell);
+
 	/* TRANSLATORS: the prefix of all the output telling the user
 	 * why it's not executing. NOTE: this is lowercase to mimic
 	 * the style of bash itself -- apologies */
-	g_printerr ("bash: %s: %s...\n", argv[1], _("command not found"));
+	g_printerr ("%s: %s: %s...\n", shell, argv[1], _("command not found"));
 
 	/* user is not allowing CNF to do anything useful */
 	if (!config->software_source_search &&


### PR DESCRIPTION
(At least on Fedora,) `/etc/profile.d/PackageKit.sh` is sourced by zsh already, but the hook function is [named differently in zsh](http://zsh.sourceforge.net/Doc/Release/Command-Execution.html). The first patch defines that function when running under zsh, which makes everything *work*.

The second is cosmetic: the name `bash` is currently hardcoded, which makes the mimicked "command not found" messages stick out. However, as described by [the zsh docs](http://zsh.sourceforge.net/Doc/Release/Command-Execution.html), zsh prints out its own message after the hook returns non-zero. So we get something like this:

```
[wjt@gelf]~/src/PackageKit% does-not-exist
zsh: does-not-exist: command not found...
zsh: command not found: does-not-exist
```

where the first message comes from `pk-command-not-found` and the second from zsh itself. If CNF has any helpful suggestions, they'll appear in between the two messages, making it look less silly. I don't think this is worth trying to do something about, really.