### PR TITLE
Correct punctuation displayed to users while applying offline updates

### DIFF
--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -422,7 +422,7 @@ main (int argc, char *argv[])
 	pk_client_set_interactive (PK_CLIENT (task), FALSE);
 	pk_offline_update_set_plymouth_mode ("updates");
 	/* TRANSLATORS: we've started doing offline updates */
-	pk_offline_update_set_plymouth_msg (_("Installing updates, this could take a while..."));
+	pk_offline_update_set_plymouth_msg (_("Installing updates; this could take a while..."));
 	pk_offline_update_write_dummy_results (package_ids);
 	results = pk_client_update_packages (PK_CLIENT (task),
 					     0,


### PR DESCRIPTION
This is a comma splice (http://en.wikipedia.org/wiki/Comma_splice), and while it's probably horribly pedantic to even mention it, it stares me in the face, taunting, whenever I update my system — so I eventually had to say something.  :)