### PR TITLE
Fixing issue from entropy and portage backends

### DIFF
--- a/backends/entropy/entropyBackend.py
+++ b/backends/entropy/entropyBackend.py
@@ -1634,7 +1634,7 @@ class PackageKitEntropyBackend(PackageKitBaseBackend, PackageKitEntropyMixin):
         self.percentage(100)
 
     @sharedreslock
-    def remove_packages(self, allowdep, autoremove, package_ids):
+    def remove_packages(self, transaction_flags, package_ids, allowdep, autoremove):
         return self._remove_packages(allowdep, autoremove, package_ids)
 
     def _remove_packages(self, allowdep, autoremove, pk_pkgs, simulate = False):
@@ -1745,6 +1745,8 @@ class PackageKitEntropyBackend(PackageKitBaseBackend, PackageKitEntropyMixin):
                     just_id = True)
                 pkg_ids |= repo_db.searchHomepage(key, just_id = True)
                 pkg_ids |= repo_db.searchLicense(key, just_id = True)
+                if not pkg_ids:
+                    pkg_ids = repo_db.searchPackages(key, just_id = True)
                 pkgs.update((repo, x, repo_db,) for x in pkg_ids)
 
         # now filter

--- a/configure.ac
+++ b/configure.ac
@@ -454,7 +454,7 @@ if test x$enable_hif = xyes; then
 fi
 
 have_python_backend="no"
-if test x$enable_entropy = xyes -o x$enable_pisi = xyes -o $enable_portage = xyes; then
+if test x$enable_entropy = xyes -o x$enable_pisi = xyes -o x$enable_portage = xyes; then
 	have_python_backend="yes"
 fi
 AM_CONDITIONAL(HAVE_PYTHON_BACKEND, test x$have_python_backend = xyes)


### PR DESCRIPTION
I tried to fix some issue with the following backend:
### Entropy Backend
 - Fixed parameters number passed to the remove function;
 - Added search by name if nothing was found in search_details, this because with gnome-packagekit the search function was completely unusable without this fix;

### Portage Backend
 - Applied various patches found [here](http://data.gpo.zugaina.org/gnome/app-admin/packagekit-base/files/) from Gilles Dartiguelongue <eva@gentoo.org> to make things works again;
 - Fixed parameters number passed to the remove function;