### PR TITLE
Failure handling

### DIFF
--- a/data/packagekit-offline-update.service.in
+++ b/data/packagekit-offline-update.service.in
@@ -1,7 +1,13 @@
 [Unit]
-Description=Updates the operating system whilst offline
-Requires=dbus.socket
-OnFailure=reboot.target
+Description=Update the operating system whilst offline
+
+DefaultDependencies=no
+Requires=sysinit.target dbus.socket
+After=sysinit.target dbus.socket systemd-journald.socket
+Before=shutdown.target system-update.target
 
 [Service]
+Type=oneshot
 ExecStart=@libexecdir@/pk-offline-update
+
+FailureAction=reboot


### PR DESCRIPTION
While testing offline updates I noticed that reboot was scheduled twice when the packagekit offline update failed (see patch one for logs). Two fixes to make sure that either failure is returned or a reboot/shutdown in scheduled.
