### PR TITLE
libpackagekit-glib: Fix introspection annotations for pk_task_resolve_*

### DIFF
--- a/lib/packagekit-glib2/pk-task-sync.c
+++ b/lib/packagekit-glib2/pk-task-sync.c
@@ -276,7 +276,7 @@ pk_task_install_files_sync (PkTask *task, gchar **files, GCancellable *cancellab
  * pk_task_resolve_sync:
  * @task: a valid #PkTask instance
  * @filters: a bitfield of filters that can be used to limit the results
- * @packages: package names to find
+ * @packages: (array zero-terminated=1): package names to find
  * @cancellable: a #GCancellable or %NULL
  * @progress_callback: (scope call): the function to run when the progress changes
  * @progress_user_data: data to pass to @progress_callback

--- a/lib/packagekit-glib2/pk-task.c
+++ b/lib/packagekit-glib2/pk-task.c
@@ -1256,7 +1256,7 @@ pk_task_install_files_async (PkTask *task, gchar **files, GCancellable *cancella
  * pk_task_resolve_async:
  * @task: a valid #PkTask instance
  * @filters: a bitfield of filters that can be used to limit the results
- * @packages: package names to find
+ * @packages: (array zero-terminated=1): package names to find
  * @cancellable: a #GCancellable or %NULL
  * @progress_callback: (scope call): the function to run when the progress changes
  * @progress_user_data: data to pass to @progress_callback


### PR DESCRIPTION
Fix 'packages' arguments in pk_task_resolve_sync / pk_task_resolve_async
which weren't marked as string arrays.