### PR TITLE
pk-offline-update: exit quietly if we didn't prepare the update

### DIFF
--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -387,6 +387,15 @@ main (int argc, char *argv[])
 		goto out;
 	}
 
+	/* check if we prepared this update; exit quietly if not */
+	if (!g_file_test (PK_OFFLINE_PREPARED_FILENAME, G_FILE_TEST_EXISTS) ||
+	    !g_file_test (PK_OFFLINE_ACTION_FILENAME, G_FILE_TEST_EXISTS)) {
+		g_print ("no update found\n");
+		sd_journal_print (LOG_INFO, "no update found");
+		retval = EXIT_SUCCESS;
+		goto out;
+	}
+
 	/* get the action, and then delete the file */
 	action = pk_offline_update_get_action ();
 	g_unlink (PK_OFFLINE_ACTION_FILENAME);


### PR DESCRIPTION
To cooperate with other things using system-update.target, the
recommended behavior is to check to see if we prepared the update,
and if not, exit quietly so as to let the other updater run.

(http://lists.freedesktop.org/archives/systemd-devel/2015-July/033623.html)

This patch makes pk-offline-update check for the action file and the
prepared update transaction; if those don't exist, exit successfully.

Resolves: rhbz#1252500