### PR TITLE
require dbus.socket for offline update

### DIFF
--- a/data/packagekit-offline-update.service.in
+++ b/data/packagekit-offline-update.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Updates the operating system whilst offline
+Requires=dbus.socket
 OnFailure=reboot.target
 
 [Service]


### PR DESCRIPTION
Looks like anything changed in systemd v228 that makes it skip to start
dbus. We need it for offline update, so add a Requires= to unit file.

This should fix Arch Linux downstream bug:
https://bugs.archlinux.org/task/47234