### PR TITLE
zypp: fix build

### DIFF
--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -3577,10 +3577,10 @@ pk_backend_start_job (PkBackend *backend, PkBackendJob *job)
 	const gchar *proxy_http;
 	const gchar *proxy_https;
 	const gchar *proxy_ftp;
-	const gchar *uri;
 	const gchar *proxy_socks;
 	const gchar *no_proxy;
 	const gchar *pac;
+	gchar *uri;
 
 	locale = pk_backend_job_get_locale(job);
 	if (!pk_strzero (locale)) {


### PR DESCRIPTION
b47f98 changed a bunch of gchar* to const gchar* to address some memory leaks.
uri should not have been touched - and it is being g_free()'d as needed.