### PR TITLE
Improve apts "history.log" logfile when using packagekit

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2556,6 +2556,14 @@ bool AptIntf::installPackages(PkBitfield flags, bool autoremove)
             //setenv("LANG", "C", 1);
         }
 
+        // apt will record this in its history.log
+        guint uid = pk_backend_job_get_uid(m_job);
+        if (uid > 0) {
+            gchar buf[16];
+            snprintf(buf, sizeof(buf), "%d", uid);
+            setenv("PACKAGEKIT_CALLER_UID", buf, 1);
+        }
+
         // Pass the write end of the pipe to the install function
         auto *progress = new Progress::PackageManagerProgressFd(readFromChildFD[1]);
         res = PM->DoInstallPostFork(progress);

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2564,6 +2564,11 @@ bool AptIntf::installPackages(PkBitfield flags, bool autoremove)
             setenv("PACKAGEKIT_CALLER_UID", buf, 1);
         }
 
+        PkRoleEnum role = pk_backend_job_get_role(m_job);
+        gchar *cmd = g_strdup_printf("packagekit role='%s'", pk_role_enum_to_string(role));
+        _config->Set("CommandLine::AsString", cmd);
+        g_free(cmd);
+
         // Pass the write end of the pipe to the install function
         auto *progress = new Progress::PackageManagerProgressFd(readFromChildFD[1]);
         res = PM->DoInstallPostFork(progress);


### PR DESCRIPTION
The apt history.log file contains log information when apt runs. By setting the "PACKAGEKIT_CALLER_UID" environment apt will log the calling user in the new "requested-by" tag. 

The "CommandLine::AsString" config option is also recorded in the log. The information stored is mostly useful so that an admin can see that this operation was performed using packagekit.