### PR TITLE
hif: Add support for build-time vendor configurations

### DIFF
--- a/backends/hif/Makefile.am
+++ b/backends/hif/Makefile.am
@@ -1,6 +1,8 @@
 plugindir = $(PK_PLUGIN_DIR)
 plugin_LTLIBRARIES = libpk_backend_hif.la
 libpk_backend_hif_la_SOURCES =						\
+	hif-backend-vendor.h						\
+	hif-backend-vendor-@HIF_VENDOR@.c				\
 	hif-backend.c							\
 	hif-backend.h							\
 	pk-backend-hif.c

--- a/backends/hif/hif-backend-vendor-fedora.c
+++ b/backends/hif/hif-backend-vendor-fedora.c
@@ -1,0 +1,46 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Neal Gompa <ngompa13@gmail.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "hif-backend-vendor.h"
+
+gboolean
+hif_validate_supported_source(const gchar* id)
+{
+	guint i;
+	const gchar *valid[] = { "fedora",
+				 "fedora-debuginfo",
+				 "fedora-source",
+				 "rawhide",
+				 "rawhide-debuginfo",
+				 "rawhide-source",
+				 "updates",
+				 "updates-debuginfo",
+				 "updates-source",
+				 "updates-testing",
+				 "updates-testing-debuginfo",
+				 "updates-testing-source",
+				 NULL };
+	for (i = 0; valid[i] != NULL; i++) {
+		if (g_strcmp0 (id, valid[i]) == 0)
+			return TRUE;
+	}
+	return FALSE;
+}

--- a/backends/hif/hif-backend-vendor-mageia.c
+++ b/backends/hif/hif-backend-vendor-mageia.c
@@ -1,0 +1,67 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Neal Gompa <ngompa13@gmail.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "hif-backend-vendor.h"
+
+gboolean
+hif_validate_supported_source(const gchar* id)
+{
+	guint i, j, k, l;
+
+	const gchar *valid_sourcesect[] = { "",
+					  "-tainted",
+					  "-nonfree",
+					  NULL };
+
+	const gchar *valid_sourcetype[] = { "",
+					  "-debuginfo",
+					  "-source",
+					  NULL };
+
+	const gchar *valid_arch[] = { "x86_64",
+				      "i586",
+				      "armv7hl",
+				      "armv5tl",
+				      NULL };
+
+	const gchar *valid[] = { "mageia",
+				 "updates",
+				 "updates_testing",
+				 "backports",
+				 "backports_testing",
+				 "cauldron",
+				 NULL };
+
+	/* Iterate over the ID arrays to find a matching identifier */
+	for (i = 0; valid[i] != NULL; i++) {
+		for (j = 0; valid_arch[j] != NULL; j++) {
+			for (k = 0; valid_sourcesect[k] != NULL; k++) {
+				for (l = 0; valid_sourcetype[l] != NULL; l++) {
+					g_autofree gchar *source_entry = g_strconcat(valid[i], "-", valid_arch[j], valid_sourcesect[k], valid_sourcetype[l], NULL);
+					if (g_strcmp0 (id, source_entry) == 0) {
+						return TRUE;
+					}
+				}
+			}
+		}
+	}
+	return FALSE;
+}

--- a/backends/hif/hif-backend-vendor.h
+++ b/backends/hif/hif-backend-vendor.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2016 Neal Gompa <ngompa13@gmail.com>
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#ifndef __HIF_BACKEND_VENDOR_H
+#define __HIF_BACKEND_VENDOR_H
+
+#include <glib.h>
+
+gboolean	hif_validate_supported_source(const gchar*);
+
+G_END_DECLS
+
+#endif /* __HIF_BACKEND_VENDOR_H */

--- a/backends/hif/pk-backend-hif.c
+++ b/backends/hif/pk-backend-hif.c
@@ -49,6 +49,7 @@ G_DEFINE_AUTOPTR_CLEANUP_FUNC(HifContext, g_object_unref)
 #include <hawkey/util.h>
 #include <librepo/librepo.h>
 
+#include "hif-backend-vendor.h"
 #include "hif-backend.h"
 
 typedef struct {
@@ -1166,33 +1167,14 @@ pk_backend_get_updates (PkBackend *backend,
 	pk_backend_job_thread_create (job, pk_backend_search_thread, NULL, NULL);
 }
 
-/* Obviously hardcoded and Fedora specific.  Colin Walters thinks this
- * concept should be based on user's trust of a GPG key or something
- * more flexible.
+/* Obviously hardcoded based on the repository ID labels.
+ * Colin Walters thinks this concept should be based on
+ * user's trust of a GPG key or something more flexible.
  */
 static gboolean
 source_is_supported (HifSource *source)
 {
-	const char *id = hif_source_get_id (source);
-	guint i;
-	const gchar *valid[] = { "fedora",
-				 "fedora-debuginfo",
-				 "fedora-source",
-				 "rawhide",
-				 "rawhide-debuginfo",
-				 "rawhide-source",
-				 "updates",
-				 "updates-debuginfo",
-				 "updates-source",
-				 "updates-testing",
-				 "updates-testing-debuginfo",
-				 "updates-testing-source",
-				 NULL };
-	for (i = 0; valid[i] != NULL; i++) {
-		if (g_strcmp0 (id, valid[i]) == 0)
-			return TRUE;
-	}
-	return FALSE;
+	return hif_validate_supported_source (hif_source_get_id (source));
 }
 
 /**

--- a/configure.ac
+++ b/configure.ac
@@ -423,6 +423,14 @@ AC_SUBST(DBUS_SERVICES_DIR)
 
 if test x$enable_hif = xyes; then
 	PKG_CHECK_MODULES(HIF, appstream-glib libhif >= 0.2.3)
+	AC_ARG_WITH(hif-vendor,
+			[AS_HELP_STRING([--with-hif-vendor=<vendor>],[select a vendor configuration (fedora, mageia; default is fedora)])])
+	if test "$with_hif_vendor" = "fedora" -o "$with_hif_vendor" = "mageia"; then
+		with_hif_vendor="$with_hif_vendor"
+	else
+		with_hif_vendor="fedora"
+	fi
+	AC_SUBST(HIF_VENDOR, [$with_hif_vendor])
 fi
 
 have_python_backend="no"
@@ -623,6 +631,7 @@ echo "
         dummy backend:             ${enable_dummy}
         Entropy backend:           ${enable_entropy}
         Hif backend:               ${enable_hif}
+        Hif backend vendor:        ${with_hif_vendor}
         PiSi backend:              ${enable_pisi}
         poldek backend:            ${enable_poldek}
         Portage backend:           ${enable_portage}


### PR DESCRIPTION
With Mageia moving forward to adopt the PackageKit-Hif backend, it is now necessary to support switching out Fedora-specific and Mageia-specific configurations at build time.

For now, this only contains <strike>swapping out repository directory locations and validating the appropriate prefixes for verifying</strike> supported sources.<strike> Fedora isn't yet using `/etc/distro.repos.d`, and other distributions in the future may use other locations</strike>. Obviously sources would differ among distributions.

In the future, support may be added for dealing with groups, which different distributions use different conventions.

I'm somewhat uncertain about the `configure.ac` modifications, because I'm not very good with autotools, but it seemed to select as I wanted to.

This pull request fixes #119.