### PR TITLE
Simply ignore the "Usage" key instead of crashing

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -611,6 +611,11 @@ pk_alpm_config_parse (PkAlpmConfig *config, const gchar *filename,
 			continue;
 		}
 
+		if (g_strcmp0 (key, "Usage") == 0 && str != NULL) {
+			/* Ignore "Usage" key instead of crashing */
+			continue;
+		}
+
 		/* report errors from above */
 		g_set_error (&e, PK_ALPM_ERROR, PK_ALPM_ERR_CONFIG_INVALID,
 			     "unrecognised directive '%s'", key);


### PR DESCRIPTION
I have not been able to figure out what I am missing in my attempt to add full support of the `Usage` config key (which can be found here: https://github.com/hughsie/PackageKit/compare/master...lots0logs:tmp122) ..so for now let's just avoid the daemon crashing by ignoring the key. This in effect means that PK will search, install, and update from all repos listed in `pacman.conf` no matter what. This shouldn't be a big deal because honestly any users who are adding `Usage` values to their config should know enough about it to realize that PK is ignoring it.

Fixes #122 