### PR TITLE
fix aptcc mimetype list

### DIFF
--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -162,7 +162,9 @@ PkBitfield pk_backend_get_filters(PkBackend *backend)
  */
 gchar** pk_backend_get_mime_types(PkBackend *backend)
 {
-    const gchar *mime_types[] = { "application/x-deb", NULL };
+    const gchar *mime_types[] = { "application/vnd.debian.binary-package",
+                                  "application/x-deb",
+                                  NULL };
     return g_strdupv ((gchar **) mime_types);
 }
 


### PR DESCRIPTION
at least with shared-mime-info 1.5 the actual mimetype is
application/vnd.debian.binary-package

```
$ mimetype ~/Downloads/steam_latest.deb
/home/me/Downloads/steam_latest.deb: application/vnd.debian.binary-package

```