### PR TITLE
zypp: Return error if invalid package IDs are detected

### DIFF
--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -2403,6 +2403,12 @@ backend_get_update_detail_thread (PkBackendJob *job, GVariant *params, gpointer 
 	for (uint i = 0; package_ids[i]; i++) {
 		sat::Solvable solvable = zypp_get_package_by_id (package_ids[i]);
 		MIL << package_ids[i] << " " << solvable << endl;
+		if (!solvable) {
+			// Previously stored package_id no longer matches any solvable.
+			zypp_backend_finished_error (job, PK_ERROR_ENUM_PACKAGE_NOT_FOUND,
+						     "couldn't find package");
+			return;
+		}
 
 		Capabilities obs = solvable.obsoletes ();
 


### PR DESCRIPTION
Fix for [boo#981011 - PackageKit dumps core](https://bugzilla.opensuse.org/981011).

If a package ID passed to `backend_get_update_detail` does not resolve to a valid solvable, subsequent code must not try to retrieve any data as all pointer derived from this solvable will be
NULL. In the current code this leads to a SEGV.