### PR TITLE
fix updates and change code to aid in not breaking this again

### DIFF
--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -853,8 +853,13 @@ static void backend_manage_packages_thread(PkBackendJob *job, GVariant *params, 
             // Updates are like installs for the purposes of resolution, we
             // want to install the updates essentially.
             installPkgs = apt->resolvePackageIds(package_ids);
-        } else {
+        } else if (role == PK_ROLE_ENUM_INSTALL_FILES) {
             installPkgs = apt->resolveLocalFiles(full_paths);
+        } else {
+            pk_backend_job_error_code(job,
+                                      PK_ERROR_ENUM_PACKAGE_NOT_FOUND,
+                                      "Could not figure out what to do to apply the change.");
+            return;
         }
 
         if (removePkgs.size() == 0 && installPkgs.size() == 0) {

--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -848,7 +848,10 @@ static void backend_manage_packages_thread(PkBackendJob *job, GVariant *params, 
         // Resolve the given packages
         if (role == PK_ROLE_ENUM_REMOVE_PACKAGES) {
             removePkgs = apt->resolvePackageIds(package_ids);
-        } else if (role == PK_ROLE_ENUM_INSTALL_PACKAGES) {
+        } else if (role == PK_ROLE_ENUM_INSTALL_PACKAGES ||
+                   role == PK_ROLE_ENUM_UPDATE_PACKAGES) {
+            // Updates are like installs for the purposes of resolution, we
+            // want to install the updates essentially.
             installPkgs = apt->resolvePackageIds(package_ids);
         } else {
             installPkgs = apt->resolveLocalFiles(full_paths);


### PR DESCRIPTION
Updates were broken in the previous local-file resolution change by eliminating it implicitly being handled in the resolution's else case. They are now once again handled as regular installs.

Additionally force expressiveness in the code by making the else case an error condition (couldn't do anything with the role) and explicitly handling local file in an else-if case.
