### PR TITLE
command-not-found: Look for dbus socket in /run instead of /var/run

### DIFF
--- a/contrib/command-not-found/PackageKit.sh.in
+++ b/contrib/command-not-found/PackageKit.sh.in
@@ -14,7 +14,7 @@ command_not_found_handle () {
 	[[ $- =~ i ]] || runcnf=0
 
 	# don't run if DBus isn't running
-	[[ ! -S /var/run/dbus/system_bus_socket ]] && runcnf=0
+	[[ ! -S /run/dbus/system_bus_socket ]] && runcnf=0
 
 	# don't run if packagekitd doesn't exist in the _system_ root
 	[[ ! -x '@LIBEXECDIR@/packagekitd' ]] && runcnf=0


### PR DESCRIPTION
I think by now pretty much all distros moved to /run

alternatively we could do something like:

> [[ ! -S /run/dbus/system_bus_socket -a ! -S /var/run/dbus/system_bus_socket ]] &&

Thus checking for both locations and accepting either of the two