### PR TITLE
Two small fixes

### DIFF
--- a/lib/packagekit-glib2/pk-task.h
+++ b/lib/packagekit-glib2/pk-task.h
@@ -284,9 +284,6 @@ gboolean	 pk_task_user_declined			(PkTask			*task,
 void		 pk_task_set_simulate			(PkTask			*task,
 							 gboolean		 simulate);
 gboolean	 pk_task_get_simulate			(PkTask			*task);
-void		 pk_task_set_interactive		(PkTask			*task,
-							 gboolean		 interactive);
-gboolean	 pk_task_get_interactive		(PkTask			*task);
 void		 pk_task_set_only_download		(PkTask			*task,
 							 gboolean		 only_download);
 gboolean	 pk_task_get_only_download		(PkTask			*task);

--- a/src/pk-backend-job.c
+++ b/src/pk-backend-job.c
@@ -490,7 +490,7 @@ pk_backend_job_set_cache_age (PkBackendJob *job, guint cache_age)
 	if (cache_age != G_MAXUINT && cache_age > cache_age_offset)
 		cache_age -= cache_age_offset;
 
-	g_debug ("cache-age changed to %i", cache_age);
+	g_debug ("cache-age changed to %u", cache_age);
 	job->priv->cache_age = cache_age;
 }
 


### PR DESCRIPTION
1. Remove declaration for non-existent function `pk_task_{get,set}_interactive()`
    
   It's a property of pk_client only.  There are no properties which exist on both pk_client and pk_task.

2. Fix "cache-age changed to -1" debug message.  (When cache-age is G_MAXUINT)