### PR TITLE
Get backends warnings on the syslog(), makes it visible on journalctl

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <sys/utsname.h>
 #include <glib/gstdio.h>
+#include <syslog.h>
 
 #include "pk-backend-alpm.h"
 #include "pk-alpm-config.h"
@@ -845,18 +846,18 @@ pk_alpm_spawn (const gchar *command)
 	g_return_val_if_fail (command != NULL, FALSE);
 
 	if (!g_spawn_command_line_sync (command, NULL, NULL, &status, &error)) {
-		g_warning ("could not spawn command: %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "could not spawn command: %s", error->message);
 		return FALSE;
 	}
 
 	if (WIFEXITED (status) == 0) {
-		g_warning ("command did not execute correctly");
+		syslog (LOG_DAEMON | LOG_WARNING, "command did not execute correctly");
 		return FALSE;
 	}
 
 	if (WEXITSTATUS (status) != EXIT_SUCCESS) {
 		gint code = WEXITSTATUS (status);
-		g_warning ("command returned error code %d", code);
+		syslog (LOG_DAEMON | LOG_WARNING, "command returned error code %d", code);
 		return FALSE;
 	}
 
@@ -881,7 +882,7 @@ pk_alpm_fetchcb (const gchar *url, const gchar *path, gint force)
 
 	oldpwd = g_get_current_dir ();
 	if (g_chdir (path) < 0) {
-		g_warning ("could not find or read directory '%s'", path);
+		syslog (LOG_DAEMON | LOG_WARNING, "could not find or read directory '%s'", path);
 		g_free (oldpwd);
 		return -1;
 	}
@@ -917,7 +918,7 @@ pk_alpm_fetchcb (const gchar *url, const gchar *path, gint force)
 	if (g_strrstr (xfercmd, "%o") != NULL) {
 		/* using .part filename */
 		if (g_rename (part, file) < 0) {
-			g_warning ("could not rename %s", part);
+			syslog (LOG_DAEMON | LOG_WARNING, "could not rename %s", part);
 			result = -1;
 			goto out;
 		}

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -26,6 +26,8 @@
 #include "pk-alpm-packages.h"
 #include "pk-alpm-transaction.h"
 
+#include <syslog.h>
+
 static off_t dcomplete = 0;
 static off_t dtotal = 0;
 
@@ -211,7 +213,7 @@ pk_alpm_transaction_progress_cb (alpm_progress_t type, const gchar *target,
 	}
 
 	if (current < 1 || targets < current)
-		g_warning ("TODO: CURRENT/TARGETS FAILED for %d", type);
+		syslog (LOG_DAEMON | LOG_WARNING, "TODO: CURRENT/TARGETS FAILED for %d", type);
 
 	g_return_if_fail (target != NULL);
 	g_return_if_fail (0 <= percent && percent <= 100);
@@ -236,12 +238,12 @@ pk_alpm_transaction_progress_cb (alpm_progress_t type, const gchar *target,
 		pk_backend_job_set_percentage (job, overall / targets);
 		recent = percent;
 
-		g_debug ("%d%% of %s complete (%zu of %zu)", percent,
+		syslog (LOG_DAEMON | LOG_WARNING, "%d%% of %s complete (%zu of %zu)", percent,
 			 target, current, targets);
 		break;
 
 	default:
-		g_warning ("unknown progress type %d", type);
+		syslog (LOG_DAEMON | LOG_WARNING, "unknown progress type %d", type);
 		break;
 	}
 }
@@ -342,7 +344,7 @@ pk_alpm_transaction_conv_cb (alpm_question_t *question)
 		break;
 
 	default:
-		g_warning ("unknown question %d", question->type);
+		syslog (LOG_DAEMON | LOG_WARNING, "unknown question %d", question->type);
 		break;
 	}
 }
@@ -717,7 +719,7 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 		break;
 
 	default:
-		g_debug ("unhandled event %d", event->type);
+		syslog (LOG_DAEMON | LOG_WARNING, "unhandled event %d", event->type);
 		break;
 	}
 }
@@ -933,7 +935,7 @@ pk_alpm_transaction_simulate (PkBackendJob *job, GError **error)
 		break;
 	default:
 		if (data != NULL)
-			g_warning ("unhandled error %d", alpm_errno (priv->alpm));
+			syslog (LOG_DAEMON | LOG_WARNING, "unhandled error %d", alpm_errno (priv->alpm));
 		break;
 	}
 
@@ -1042,7 +1044,7 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 		break;
 	default:
 		if (data != NULL) {
-			g_warning ("unhandled error %d",
+			syslog (LOG_DAEMON | LOG_WARNING, "unhandled error %d",
 				   alpm_errno (priv->alpm));
 		}
 		break;

--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -25,6 +25,7 @@
 
 #include <glib/gstdio.h>
 #include <glib/gthread.h>
+#include <syslog.h>
 #include <pk-backend.h>
 
 #include "pk-backend-alpm.h"
@@ -65,11 +66,11 @@ pk_alpm_logcb (alpm_loglevel_t level, const gchar *format, va_list args)
 		g_debug ("%s", output);
 		break;
 	case ALPM_LOG_WARNING:
-		g_warning ("%s", output);
+		syslog (LOG_DAEMON | LOG_WARNING, "%s", output);
 		pk_alpm_transaction_output (output);
 		break;
 	default:
-		g_warning ("%s", output);
+		syslog (LOG_DAEMON | LOG_WARNING, "%s", output);
 		break;
 	}
 }

--- a/backends/aptcc/apt-cache-file.cpp
+++ b/backends/aptcc/apt-cache-file.cpp
@@ -23,6 +23,7 @@
 
 #include <sstream>
 #include <cstdio>
+#include <syslog.h>
 #include <apt-pkg/algorithms.h>
 #include <apt-pkg/progress.h>
 #include <apt-pkg/upgrade.h>
@@ -101,12 +102,12 @@ bool AptCacheFile::CheckDeps(bool AllowBroken)
         // We failed to fix the cache
         ShowBroken(true, PK_ERROR_ENUM_UNFINISHED_TRANSACTION);
 
-        g_warning("Unable to correct dependencies");
+        syslog (LOG_DAEMON | LOG_WARNING, "Unable to correct dependencies");
         return false;
     }
 
     if (pkgMinimizeUpgrade(*DCache) == false) {
-        g_warning("Unable to minimize the upgrade set");
+        syslog (LOG_DAEMON | LOG_WARNING, "Unable to minimize the upgrade set");
         show_errors(m_job, PK_ERROR_ENUM_INTERNAL_ERROR);
         return false;
     }

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -40,6 +40,7 @@
 #include <memory>
 #include <fstream>
 #include <dirent.h>
+#include <syslog.h>
 
 #include "apt-cache-file.h"
 #include "apt-utils.h"
@@ -2009,7 +2010,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
 
     if ((now - m_lastTermAction) > m_terminalTimeout) {
         // get some debug info
-        g_warning("no statusfd changes/content updates in terminal for %i"
+        syslog (LOG_DAEMON | LOG_WARNING, "no statusfd changes/content updates in terminal for %i"
                   " seconds",m_terminalTimeout);
         m_lastTermAction = time(NULL);
     }
@@ -2398,7 +2399,7 @@ bool AptIntf::installPackages(PkBitfield flags, bool autoremove)
     pkgPackageManager::OrderResult res;
     res = PM->DoInstallPreFork();
     if (res == pkgPackageManager::Failed) {
-        g_warning ("Failed to prepare installation");
+        syslog (LOG_DAEMON | LOG_WARNING, "Failed to prepare installation");
         show_errors(m_job, PK_ERROR_ENUM_PACKAGE_DOWNLOAD_FAILED);
         return false;
     }

--- a/backends/aptcc/deb-file.cpp
+++ b/backends/aptcc/deb-file.cpp
@@ -22,6 +22,7 @@
 
 #include "deb-file.h"
 
+#include <syslog.h>
 #include <glib.h>
 #include <apt-pkg/init.h>
 
@@ -49,7 +50,7 @@ DebFile::DebFile(const string &filename)
     }
 
     if(!m_controlData.Scan(m_extractor->Control,m_extractor->Length+2)) {
-        g_warning("DebFile: Scan failed.");
+        syslog (LOG_DAEMON | LOG_WARNING, "DebFile: Scan failed.");
         return;
     }
 

--- a/backends/dnf/dnf-backend.c
+++ b/backends/dnf/dnf-backend.c
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <syslog.h>
 
 #include <libdnf/libdnf.h>
 
@@ -207,7 +208,7 @@ dnf_advisory_kind_to_info_enum (DnfAdvisoryKind kind)
 		info_enum = PK_INFO_ENUM_ENHANCEMENT;
 		break;
 	default:
-		g_warning ("Failed to find DnfAdvisoryKind enum %i", kind);
+		syslog (LOG_DAEMON | LOG_WARNING, "Failed to find DnfAdvisoryKind enum %i", kind);
 		break;
 	}
 	return info_enum;

--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -26,6 +26,7 @@
 #include <gmodule.h>
 #include <glib.h>
 #include <glib/gstdio.h>
+#include <syslog.h>
 #include <string.h>
 #include <appstream-glib.h>
 
@@ -1457,7 +1458,7 @@ pk_backend_refresh_source (PkBackendJob *job,
 			if (g_error_matches (error_local,
 					     DNF_ERROR,
 					     PK_ERROR_ENUM_CANNOT_FETCH_SOURCES)) {
-				g_warning ("Skipping refresh of %s: %s",
+				syslog (LOG_DAEMON | LOG_WARNING, "Skipping refresh of %s: %s",
 					   dnf_repo_get_id (src),
 					   error_local->message);
 				g_clear_error (&error_local);
@@ -1483,7 +1484,7 @@ pk_backend_refresh_source (PkBackendJob *job,
 				return FALSE;
 			}
 #else
-			g_warning ("need to install AppStream metadata %s", tmp);
+			syslog (LOG_DAEMON | LOG_WARNING, "need to install AppStream metadata %s", tmp);
 #endif
 		}
 	}

--- a/backends/dummy/pk-backend-dummy.c
+++ b/backends/dummy/pk-backend-dummy.c
@@ -1496,7 +1496,7 @@ void
 pk_backend_repo_set_data (PkBackend *backend, PkBackendJob *job, const gchar *rid, const gchar *parameter, const gchar *value)
 {
 	pk_backend_job_set_status (job, PK_STATUS_ENUM_REQUEST);
-	g_warning ("REPO '%s' PARAMETER '%s' TO '%s'", rid, parameter, value);
+	g_warning("REPO '%s' PARAMETER '%s' TO '%s'", rid, parameter, value);
 
 	if (g_strcmp0 (parameter, "use-blocked") == 0)
 		priv->use_blocked = atoi (value);

--- a/backends/hif/hif-backend.c
+++ b/backends/hif/hif-backend.c
@@ -21,6 +21,7 @@
 
 #include "config.h"
 
+#include <syslog.h>
 #include <stdlib.h>
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -203,7 +204,7 @@ hif_advisory_type_to_info_enum (HyAdvisoryType type)
 		info_enum = PK_INFO_ENUM_ENHANCEMENT;
 		break;
 	default:
-		g_warning ("Failed to find HyAdvisoryType enum %i", type);
+		syslog (LOG_DAEMON | LOG_WARNING, "Failed to find HyAdvisoryType enum %i", type);
 		break;
 	}
 	return info_enum;

--- a/backends/hif/pk-backend-hif.c
+++ b/backends/hif/pk-backend-hif.c
@@ -23,6 +23,7 @@
 #  include <config.h>
 #endif
 
+#include <syslog.h>
 #include <gmodule.h>
 #include <glib.h>
 #include <glib/gstdio.h>
@@ -1468,7 +1469,7 @@ pk_backend_refresh_source (PkBackendJob *job,
 			if (g_error_matches (error_local,
 					     HIF_ERROR,
 					     PK_ERROR_ENUM_CANNOT_FETCH_SOURCES)) {
-				g_warning ("Skipping refresh of %s: %s",
+				syslog (LOG_DAEMON | LOG_WARNING, "Skipping refresh of %s: %s",
 					   hif_source_get_id (src),
 					   error_local->message);
 				g_clear_error (&error_local);
@@ -1494,7 +1495,7 @@ pk_backend_refresh_source (PkBackendJob *job,
 				return FALSE;
 			}
 #else
-			g_warning ("need to install AppStream metadata %s", tmp);
+			syslog (LOG_DAEMON | LOG_WARNING, "need to install AppStream metadata %s", tmp);
 #endif
 		}
 	}

--- a/backends/yum/pk-backend-yum.c
+++ b/backends/yum/pk-backend-yum.c
@@ -24,6 +24,7 @@
 #include <pk-backend.h>
 #include <pk-backend-spawn.h>
 #include <string.h>
+#include <syslog.h>
 #include <packagekit-glib2/pk-debug.h>
 
 #define PREUPGRADE_BINARY			"/usr/bin/preupgrade"
@@ -131,7 +132,7 @@ pk_backend_enable_media_repo (gboolean enabled)
 	g_key_file_set_integer (keyfile, "InstallMedia", "enabled", enabled);
 	data = g_key_file_to_data (keyfile, NULL, &error);
 	if (data == NULL) {
-		g_warning ("failed to get data: %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "failed to get data: %s", error->message);
 		g_error_free (error);
 		goto out;
 	}
@@ -139,7 +140,7 @@ pk_backend_enable_media_repo (gboolean enabled)
 	/* save */
 	ret = g_file_set_contents (PACKAGE_MEDIA_REPO_FILENAME, data, -1, &error);
 	if (!ret) {
-		g_warning ("failed to save %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "failed to save %s", error->message);
 		g_error_free (error);
 		goto out;
 	}
@@ -179,7 +180,7 @@ pk_backend_mount_add (GMount *mount, gpointer user_data)
 	/* copy to the system repo dir */
 	ret = g_file_copy (repo, dest, G_FILE_COPY_OVERWRITE, NULL, NULL, NULL, &error);
 	if (!ret) {
-		g_warning ("failed to copy: %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "failed to copy: %s", error->message);
 		g_error_free (error);
 	}
 out:
@@ -231,7 +232,7 @@ pk_backend_initialize (GKeyFile *conf, PkBackend *backend)
 	if (priv->monitor != NULL) {
 		g_signal_connect (priv->monitor, "changed", G_CALLBACK (pk_backend_yum_repos_changed_cb), backend);
 	} else {
-		g_warning ("failed to setup monitor: %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "failed to setup monitor: %s", error->message);
 		g_error_free (error);
 	}
 
@@ -241,7 +242,7 @@ pk_backend_initialize (GKeyFile *conf, PkBackend *backend)
 	g_debug ("loading configuration from %s", config_file);
 	ret = g_key_file_load_from_file (key_file, config_file, G_KEY_FILE_NONE, &error);
 	if (!ret) {
-		g_warning ("failed to load Yum.conf: %s", error->message);
+		syslog (LOG_DAEMON | LOG_WARNING, "failed to load Yum.conf: %s", error->message);
 		g_error_free (error);
 		goto out;
 	}

--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -43,6 +43,7 @@
 #include <gmodule.h>
 #include <pk-backend.h>
 #include <pk-shared.h>
+#include <syslog.h>
 #define I_KNOW_THE_PACKAGEKIT_GLIB2_API_IS_SUBJECT_TO_CHANGE
 #include <packagekit-glib2/packagekit.h>
 #include <packagekit-glib2/pk-enum.h>
@@ -729,7 +730,7 @@ zypp_build_pool (ZYpp::Ptr zypp, gboolean include_local)
 				continue;
 			// skip not cached repos
 			if (manager.isCached (repo) == false) {
-				g_warning ("%s is not cached! Do a refresh", repo.alias ().c_str ());
+				syslog (LOG_DAEMON | LOG_WARNING, "%s is not cached! Do a refresh", repo.alias ().c_str ());
 				continue;
 			}
 			//FIXME see above, skip already cached repos
@@ -3381,7 +3382,7 @@ backend_what_provides_thread (PkBackendJob *job, GVariant *params, gpointer user
 		if (!solver.resolvePool ()) {
 			list<ResolverProblem_Ptr> problems = solver.problems ();
 			for (list<ResolverProblem_Ptr>::iterator it = problems.begin (); it != problems.end (); ++it){
-				g_warning("Solver problem (This should never happen): '%s'", (*it)->description ().c_str ());
+				syslog (LOG_DAEMON | LOG_WARNING, "Solver problem (This should never happen): '%s'", (*it)->description ().c_str ());
 			}
 			solver.setIgnoreAlreadyRecommended (FALSE);
 			zypp_backend_finished_error (


### PR DESCRIPTION
Should allow more efficient issue reporting.
Should help detecting regressions when the backend behaviors change.
Otherwise, the output we generate goes to /dev/null, which is possibly
fine for g_debug but in this case we're not being warned.