### PR TITLE
Fix redeclaration of polkit autocleanup functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,6 +183,14 @@ PKG_CHECK_MODULES(GIO, \
 PKG_CHECK_MODULES(POLKIT, \
 		  polkit-gobject-1 >= $POLKIT_GOBJECT_REQUIRED)
 
+# 0.114 introduced autocleanup functions for its types.
+PKG_CHECK_MODULES([POLKIT_0_114], [polkit-gobject-1 >= 0.114],
+                  [have_polkit_0_114=yes], [have_polkit_0_114=no])
+AS_IF([test "$have_polkit_0_114" = "yes"], [
+	AC_DEFINE([HAVE_POLKIT_0_114],[1],
+	          [Define as 1 if you have polkit >= 0.114])
+])
+
 # Avoid g_simple_async_result deprecation warnings in glib 2.46+
 AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, GLIB_VERSION_2_44, [minimum glib version])
 

--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -51,7 +51,7 @@
 #include "pk-transaction.h"
 #include "pk-scheduler.h"
 
-#ifndef glib_autoptr_cleanup_PolkitAuthorizationResult
+#ifndef HAVE_POLKIT_0_114
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitSubject, g_object_unref)
 #endif

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -56,7 +56,7 @@
 #include "pk-transaction.h"
 #include "pk-transaction-private.h"
 
-#ifndef glib_autoptr_cleanup_PolkitAuthorizationResult
+#ifndef HAVE_POLKIT_0_114
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitAuthorizationResult, g_object_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(PolkitDetails, g_object_unref)
 #endif


### PR DESCRIPTION
ifdef cannot be used to determine if a C symbol is defined, as it’s
evaluated by the preprocessor, before symbols are parsed. Instead of
trying to detect whether polkit.h is suitably recent enough to define
its own auto-cleanup functions, just define our own in a different
namespace which is guaranteed not to collide with upstream.