### PR TITLE
aptcc: fix ac_compile_ifelse

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -476,14 +476,14 @@ if test x$enable_aptcc = xyes; then
 	AC_SUBST(GSTREAMER_LIBS)
 
 	AC_MSG_CHECKING([whether apt is at least at version 1.1])
-	AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[#include <apt-pkg/pkgsystem.h>]],
-					  [[_system->ArchitecturesSupported();]]),
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <apt-pkg/pkgsystem.h>]],
+					  [[_system->ArchitecturesSupported();]])],
 			  AC_MSG_RESULT([yes]),
 			  AC_MSG_FAILURE([need libapt-pkg 1.1 or later]))
 
 	AC_MSG_CHECKING([whether apt supports ddtp])
-	AC_COMPILE_IFELSE(AC_LANG_PROGRAM([[#include <apt-pkg/pkgcache.h>]],
-					  [[pkgCache::DescIterator d;]]),
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <apt-pkg/pkgcache.h>]],
+					  [[pkgCache::DescIterator d;]])],
 			  AC_MSG_RESULT([yes])
 			  AC_DEFINE([HAVE_DDTP], [], [Set to true if apt is DDTP-enabled]),
 			  AC_MSG_RESULT([no]))


### PR DESCRIPTION
Remove warnings as stated in https://autotools.io/forwardporting/autoconf.html