### PR TITLE
[aptcc] Specify status when calling pk_backend_job_set_item_progress

### DIFF
--- a/backends/aptcc/acqpkitstatus.cpp
+++ b/backends/aptcc/acqpkitstatus.cpp
@@ -211,6 +211,6 @@ void AcqPackageKitStatus::updateStatus(pkgAcquire::ItemDesc & Itm, int status)
         m_apt->emitPackage(ver, PK_INFO_ENUM_DOWNLOADING);
         
         // Emit the individual progress
-        m_apt->emitPackageProgress(ver, status);
+        m_apt->emitPackageProgress(ver, PK_STATUS_ENUM_DOWNLOAD, status);
     }
 }

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -434,11 +434,11 @@ void AptIntf::emitPackage(const pkgCache::VerIterator &ver, PkInfoEnum state)
     g_free(package_id);
 }
 
-void AptIntf::emitPackageProgress(const pkgCache::VerIterator &ver, uint percentage)
+void AptIntf::emitPackageProgress(const pkgCache::VerIterator &ver, PkStatusEnum status, uint percentage)
 {
     gchar *package_id;
     package_id = utilBuildPackageId(ver);
-    pk_backend_job_set_item_progress(m_job, package_id, PK_STATUS_ENUM_UNKNOWN, percentage);
+    pk_backend_job_set_item_progress(m_job, package_id, status, percentage);
     g_free(package_id);
 }
 
@@ -1883,7 +1883,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_PREPARING);
-                        emitPackageProgress(ver, 75);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_SETUP, 75);
                     }
                 } else if (starts_with(str, "Preparing for removal")) {
                     // Preparing to Install/configure
@@ -1892,7 +1892,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_REMOVING);
-                        emitPackageProgress(ver, m_lastSubProgress);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_SETUP, m_lastSubProgress);
                     }
                 } else if (starts_with(str, "Preparing")) {
                     // Preparing to Install/configure
@@ -1900,14 +1900,14 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_PREPARING);
-                        emitPackageProgress(ver, 25);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_SETUP, 25);
                     }
                 } else if (starts_with(str, "Unpacking")) {
                     // cout << "Found Unpacking! " << line << endl;
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_DECOMPRESSING);
-                        emitPackageProgress(ver, 50);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_INSTALL, 50);
                     }
                 } else if (starts_with(str, "Configuring")) {
                     // Installing Package
@@ -1924,7 +1924,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_INSTALLING);
-                        emitPackageProgress(ver, m_lastSubProgress);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_INSTALL, m_lastSubProgress);
                     }
                     m_lastSubProgress += 25;
                 } else if (starts_with(str, "Running dpkg")) {
@@ -1946,7 +1946,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_INSTALLING);
-                        emitPackageProgress(ver, m_lastSubProgress);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_INSTALL, m_lastSubProgress);
                     }
                 } else if (starts_with(str, "Removing")) {
                     // cout << "Found Removing! " << line << endl;
@@ -1962,7 +1962,7 @@ void AptIntf::updateInterface(int fd, int writeFd)
                     const pkgCache::VerIterator &ver = findTransactionPackage(pkg);
                     if (!ver.end()) {
                         emitPackage(ver, PK_INFO_ENUM_REMOVING);
-                        emitPackageProgress(ver, m_lastSubProgress);
+                        emitPackageProgress(ver, PK_STATUS_ENUM_REMOVE, m_lastSubProgress);
                     }
                 } else if (starts_with(str, "Installed") ||
                            starts_with(str, "Removed")) {

--- a/backends/aptcc/apt-intf.h
+++ b/backends/aptcc/apt-intf.h
@@ -157,7 +157,7 @@ public:
     /**
      *  Emits a package with the given percentage
      */
-    void emitPackageProgress(const pkgCache::VerIterator &ver, uint percentage);
+    void emitPackageProgress(const pkgCache::VerIterator &ver, PkStatusEnum status, uint percentage);
 
     /**
       * Emits a list of packages that matches the given filters


### PR DESCRIPTION
At the moment we always returned PK_STATUS_ENUM_UNKNOWN and it was hard
to keep track of what was happening.

Should improve issue #159.