### PR TITLE
pk-progress-bar: checks NULL strings inside pk_progress_bar_start () [v2].

### DIFF
--- a/lib/packagekit-glib2/pk-progress-bar.c
+++ b/lib/packagekit-glib2/pk-progress-bar.c
@@ -268,8 +268,10 @@ pk_progress_bar_start (PkProgressBar *self, const gchar *text)
 	g_return_val_if_fail (PK_IS_PROGRESS_BAR (self), FALSE);
 
 	/* same as last time */
-	if (g_strcmp0 (self->priv->old_start_text, text) == 0)
-		return TRUE;
+	if (self->priv->old_start_text != NULL && text != NULL) {
+		if (g_strcmp0 (self->priv->old_start_text, text) == 0)
+			return TRUE;
+	}
 	g_free (self->priv->old_start_text);
 	self->priv->old_start_text = g_strdup (text);
 


### PR DESCRIPTION
This commit adds a conditional to check if the string of progress bar
and text input are NULL. The comparison needs to be executed with two
valid strings and not two NULL pointes. That's why the conditional has
an AND operator. Both needs to be an empty string or a valid string, not
a NULL pointer. This missing check is causing an error during the pkcon
execution. See the command output:

    $ sudo pkcon repair
    FIXME: need to call pk_progress_bar_start()
    earlier![=========================]
    Finished                      [=========================]
                                  [=========================]
    Testing changes               [=========================]
    Finished                      [=========================]

After patching:

    $ sudo pkcon repair
                                  [=========================]
    Finished                      [=========================]
                                  [=========================]
    Testing changes               [=========================]
    Finished                      [=========================]

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>