### PR TITLE
pk-main: segfault when config file is not found [v2].

### DIFF
--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -173,6 +173,10 @@ main (int argc, char *argv[])
 	/* get values from the config file */
 	conf = g_key_file_new ();
 	conf_filename = pk_util_get_config_filename ();
+	if (conf_filename == NULL) {
+		g_print ("Cannot found config file.");
+		goto out;
+	}
 	ret = g_key_file_load_from_file (conf, conf_filename,
 					 G_KEY_FILE_NONE, &error);
 	if (!ret) {


### PR DESCRIPTION
When the config file used by PackageKit daemon is not found, the
function `pk_util_get_config_filename()` returns a NULL pointer.

See:
https://github.com/hughsie/PackageKit/blob/master/src/pk-shared.c#L300

So, when `g_key_file_load_from_file()` is called, the variable
`conf_filename` is NULL and inside that function the `assert()` fails:

    $ sudo packagekitd

    (packagekitd:9133): GLib-CRITICAL **: g_key_file_load_from_file:
    assertion 'file != NULL' failed
    Segmentation fault

This commit fixes the problem.

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>