### PR TITLE
aptcc: Fix installing gst codecs for gstreamer 1.0

### DIFF
--- a/backends/aptcc/gst-matcher.cpp
+++ b/backends/aptcc/gst-matcher.cpp
@@ -23,9 +23,14 @@
 #include <regex.h>
 #include <gst/gst.h>
 
+static bool inited = false;
+
 GstMatcher::GstMatcher(gchar **values)
 {
-    gst_init(NULL, NULL);
+    if (!inited) {
+        gst_init(NULL, NULL);
+        inited = true;
+    }
 
     // The search term from PackageKit daemon:
     // gstreamer0.10(urisource-foobar)
@@ -113,8 +118,6 @@ GstMatcher::GstMatcher(gchar **values)
 
 GstMatcher::~GstMatcher()
 {
-    gst_deinit();
-
     for (const Match &match : m_matches) {
         gst_caps_unref(static_cast<GstCaps*>(match.caps));
     }


### PR DESCRIPTION
The regex didn't work with gstreamer 1.0 input.

Try

  pkcon what-provides 'gstreamer1.0(decoder-audio/mpeg)(mpegaudioversion=1)(mpegversion=1)(layer=3)'

to test.

Also, the second commit fixes a critical and no results that happen for the non-first queries. You can't deinit and then init again - it breaks gstreamer.

@ximion Please test this. I don't know much about this stuff. I think there's a way to request multiple codecs at once - how do you do that? I don't know and so I didn't test it. :)

Fixes #192.