### PR TITLE
zypp: Fix stack smashing on 32-bit system

### DIFF
--- a/backends/zypp/Makefile.am
+++ b/backends/zypp/Makefile.am
@@ -9,6 +9,6 @@ libpk_backend_zypp_la_LIBADD = $(PK_PLUGIN_LIBS)
 libpk_backend_zypp_la_LDFLAGS = -module -avoid-version $(ZYPP_LIBS)
 libpk_backend_zypp_la_CFLAGS = $(PK_PLUGIN_CFLAGS) $(WARNINGFLAGS_CPP)
 libpk_backend_zypp_la_CXXFLAGS = $(PK_PLUGIN_CXXFLAGS) --std=c++0x -Wall -Woverloaded-virtual -Wnon-virtual-dtor
-libpk_backend_zypp_la_CPPFLAGS = $(PK_PLUGIN_CFLAGS) $(ZYPP_CFLAGS) -Wno-deprecated
+libpk_backend_zypp_la_CPPFLAGS = $(PK_PLUGIN_CFLAGS) $(ZYPP_CFLAGS) -Wno-deprecated -D_FILE_OFFSET_BITS=64
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
PackageKit(using zypp backend) will crash when running
"pkcon get-updates" on 32-bit system.

Fix that by adding -D_FILE_OFFSET_BITS=64 to
libpk_backend_zypp_la_CPPFLAGS.

https://bugs.freedesktop.org/show_bug.cgi?id=101267