### PR TITLE
aptcc: Support "()(64bit)"

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -538,6 +538,12 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
             continue;
         }
 
+        // Ignore debug packages - these aren't interesting as codec providers,
+        // but they do have apt GStreamer-* metadata.
+        if (ends_with (pkg.Name(), "-dbg") || ends_with (pkg.Name(), "-dbgsym")) {
+            continue;
+        }
+
         // TODO search in updates packages
         // Ignore virtual packages
         pkgCache::VerIterator ver = m_cache->findVer(pkg);

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -521,6 +521,7 @@ void AptIntf::emitUpdates(PkgList &output, PkBitfield filters)
 // search packages which provide a codec (specified in "values")
 void AptIntf::providesCodec(PkgList &output, gchar **values)
 {
+    string arch;
     GstMatcher *matcher = new GstMatcher(values);
     if (!matcher->hasMatches()) {
         return;
@@ -540,6 +541,7 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
         // TODO search in updates packages
         // Ignore virtual packages
         pkgCache::VerIterator ver = m_cache->findVer(pkg);
+        arch = string(ver.Arch());
         if (ver.end() == true) {
             ver = m_cache->findCandidateVer(pkg);
             if (ver.end() == true) {
@@ -552,7 +554,7 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
         const char *start, *stop;
         rec.GetRec(start, stop);
         string record(start, stop - start);
-        if (matcher->matches(record)) {
+        if (matcher->matches(record, arch)) {
             output.push_back(ver);
         }
     }

--- a/backends/aptcc/gst-matcher.cpp
+++ b/backends/aptcc/gst-matcher.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "gst-matcher.h"
+#include "apt-utils.h"
 
 #include <regex.h>
 #include <gst/gst.h>
@@ -72,7 +73,7 @@ GstMatcher::GstMatcher(gchar **values)
                     // This is hardcoded in pk-gstreamer-install, so we also hardcode it here
                     const string x86_64 = "()(64bit";
 
-                    if (equal(x86_64.rbegin(), x86_64.rend(), opt.rbegin())) {
+                    if (ends_with(opt.c_str(), x86_64.c_str())) {
                             // We hardcode 64bit -> amd64 here
                             arch = "amd64";
                             // -1 -> remove the last )

--- a/backends/aptcc/gst-matcher.h
+++ b/backends/aptcc/gst-matcher.h
@@ -34,6 +34,7 @@ typedef struct {
     string   data;
     string   opt;
     void    *caps;
+    string   arch;
 } Match;
 
 class GstMatcher
@@ -42,7 +43,7 @@ public:
     GstMatcher(gchar **values);
     ~GstMatcher();
 
-    bool matches(string record);
+    bool matches(string record, string arch);
     bool hasMatches() const;
 
 private:


### PR DESCRIPTION
This is sent by pk-gstreamer-install.

We special-case this and use it to limit our search to 'amd64' packages
only.

In the future this should be extended to any 64 bit arch, I think.

---

Without this, we get:

```
laney@raleigh (master|…)> pkcon what-provides 'gstreamer1(decoder-audio/mpeg)(mpegaudioversion=1)(mpegversion=1)(layer=3)()(64bit)'
Getting provides              [=========================]         
Loading cache                 [=========================]         
Querying                      [=========================]         
Finished                      [=========================]         
laney@raleigh (master|…)>
```

And with it:

```
laney@raleigh (master|…)> pkcon what-provides 'gstreamer1(decoder-audio/mpeg)(mpegaudioversion=1)(mpegversion=1)(layer=3)()(64bit)'   
Getting provides              [=========================]         
Loading cache                 [=========================]         
Querying                      [=========================]         
Finished                      [=========================]         
Available   	gstreamer1.0-fluendo-mp3-0.10.32.debian-1.amd64 (ubuntu-artful-universe)	Fluendo mp3 decoder GStreamer 1.0 plugin
Installed   	gstreamer1.0-libav-1.12.1-1.amd64 (installed:ubuntu-artful-universe)	libav plugin for GStreamer
Installed   	gstreamer1.0-plugins-good-1.12.1-1ubuntu1.amd64 (installed:._artful-artful-main)	GStreamer plugins from the "good" set
Installed   	gstreamer1.0-plugins-ugly-1.12.1-1.amd64 (installed:ubuntu-artful-universe)	GStreamer plugins from the "ugly" set
```

I also included a fix to ignore debug packages when querying for codecs - they're not useful.