### PR TITLE
aptcc: Don't return installed packages for codec search

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -537,6 +537,14 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
             continue;
         }
 
+        // Ignore installed packages - we're being told that we don't have the
+        // codec, so installed packages can't satisfy what we're after. In
+        // particular, the caps syntax currently doesn't allow us to filter out
+        // -good when requesting packages for MP3s.
+        if (pkg->CurrentState == pkgCache::State::Installed) {
+            continue;
+        }
+
         // TODO search in updates packages
         // Ignore virtual packages
         pkgCache::VerIterator ver = m_cache->findVer(pkg);


### PR DESCRIPTION
It doesn't seem possible to perform this search properly with the
information we have. In particular we almost always say that '-good' is
a candidate when it might not be. '-good' is almost always installed, so
it is good enough to filter out installed packages.

The argument as to why this is okay to do is that if the user is being
shown the dialog then it's because they don't have a codec installed, so
it's not that helpful to show installed packages.

@ximion another for you - is this a good idea? I looked for a while and I can't see how to filter out -good using caps.