### PR TITLE
alpm: read the session proxy settings for each job

### DIFF
--- a/backends/alpm/pk-alpm-environment.c
+++ b/backends/alpm/pk-alpm-environment.c
@@ -54,35 +54,46 @@ pk_alpm_environment_initialize (PkBackendJob *job)
 	if (!pk_strzero (tmp)) {
 		g_autofree gchar *uri = pk_backend_convert_uri (tmp);
 		g_setenv ("http_proxy", uri, TRUE);
+	} else {
+		g_unsetenv ("http_proxy");
 	}
 
 	tmp = pk_backend_job_get_proxy_https (job);
 	if (!pk_strzero (tmp)) {
 		g_autofree gchar *uri = pk_backend_convert_uri (tmp);
 		g_setenv ("https_proxy", uri, TRUE);
+	} else {
+		g_unsetenv ("https_proxy");
 	}
 
 	tmp = pk_backend_job_get_proxy_ftp (job);
 	if (!pk_strzero (tmp)) {
 		g_autofree gchar *uri = pk_backend_convert_uri (tmp);
 		g_setenv ("ftp_proxy", uri, TRUE);
+	} else {
+		g_unsetenv ("ftp_proxy");
 	}
 
 	tmp = pk_backend_job_get_proxy_socks (job);
 	if (!pk_strzero (tmp)) {
 		g_autofree gchar *uri = pk_backend_convert_uri_socks (tmp);
 		g_setenv ("all_proxy", uri, TRUE);
+	} else {
+		g_unsetenv ("all_proxy");
 	}
 
 	tmp = pk_backend_job_get_no_proxy (job);
 	if (!pk_strzero (tmp)) {
 		g_setenv ("no_proxy", tmp, TRUE);
+	} else {
+		g_unsetenv ("no_proxy");
 	}
 
 	tmp = pk_backend_job_get_pac (job);
 	if (!pk_strzero (tmp)) {
 		g_autofree gchar *uri = pk_backend_convert_uri (tmp);
 		g_setenv ("pac", uri, TRUE);
+	} else {
+		g_unsetenv ("pac");
 	}
 }
-

--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -225,10 +225,5 @@ pk_alpm_finish (PkBackendJob *job, GError *error)
 void
 pk_backend_start_job (PkBackend *backend, PkBackendJob *job)
 {
-	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
-	if (g_once_init_enter (&priv->environment_initialized))
-	{
-		pk_alpm_environment_initialize (job);
-		g_once_init_leave (&priv->environment_initialized, TRUE);
-	}
+	pk_alpm_environment_initialize (job);
 }

--- a/backends/alpm/pk-backend-alpm.h
+++ b/backends/alpm/pk-backend-alpm.h
@@ -26,7 +26,6 @@
 #include <pk-backend.h>
 
 typedef struct {
-	gsize		environment_initialized;
 	alpm_db_t	*localdb;
 	alpm_list_t	*syncfirsts;
 	alpm_list_t	*holdpkgs;


### PR DESCRIPTION
If we set the proxy only once, the user won't be able to update it
without killing the daemon.