### PR TITLE
service: Use ConditionPathExists=!/run/ostree-booted

### DIFF
--- a/data/packagekit-offline-update.service.in
+++ b/data/packagekit-offline-update.service.in
@@ -5,6 +5,8 @@ DefaultDependencies=no
 Requires=sysinit.target dbus.socket
 After=sysinit.target dbus.socket systemd-journald.socket
 Before=shutdown.target system-update.target
+# See packagekit.service
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=oneshot

--- a/data/packagekit.service.in
+++ b/data/packagekit.service.in
@@ -1,5 +1,9 @@
 [Unit]
 Description=PackageKit Daemon
+# PK doesn't know how to do anything on ostree-managed systems;
+# currently the design is to have dedicated daemons like
+# eos-updater and rpm-ostree, and gnome-software talks to those.
+ConditionPathExists=!/run/ostree-booted
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Today gnome-shell unconditionally tries to talk to PK, which doesn't
really do anything useful for ostree-managed systems (including rpm-ostree),
for example Fedora Atomic Workstation.

This is similar to https://github.com/rpm-software-management/dnf/pull/723