### PR TITLE
aptcc: do not crash on double free when updating a config file

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -1789,7 +1789,6 @@ void AptIntf::updateInterface(int fd, int writeFd)
                 int exit_code = WEXITSTATUS(exitStatus);
                 cout << filename << " " << exit_code << " ret: "<< ret << endl;
 
-                g_free(filename);
                 g_strfreev(argv);
                 g_strfreev(envp);
 


### PR DESCRIPTION
filename is being inserted into the argv array, this results in a double
free when we later free filename (first) AND then the argv array (second)