### PR TITLE
Fix getting user session ID with D-Bus "user bus" model

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ dnl ---------------------------------------------------------------------------
 AC_ARG_ENABLE(systemd, AS_HELP_STRING([--enable-systemd],[enable systemd and logind code]),
 	      enable_systemd=$enableval,enable_systemd=yes)
 if test x$enable_systemd = xyes; then
-	PKG_CHECK_MODULES(SYSTEMD, libsystemd)
+	PKG_CHECK_MODULES(SYSTEMD, libsystemd >= 213)
 	AC_ARG_WITH([systemdsystemunitdir],
 		    AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
 		    [has_systemdsystemunitdir=$with_systemdsystemunitdir],


### PR DESCRIPTION
In case a PackageKit requesting process is not part of the user's login
session, we ask systemd-logind for the the user's "display" session
instead.

This fixes gnome-software "failed to set proxy" warnings.

https://bugs.freedesktop.org/show_bug.cgi?id=101281