### PR TITLE
urpmi: typo fix inside pk_backend_get_author().

### DIFF
--- a/backends/urpmi/pk-backend-urpmi.c
+++ b/backends/urpmi/pk-backend-urpmi.c
@@ -40,7 +40,7 @@ const gchar *
 pk_backend_get_author (PkBackend *backend)
 {
 	return "Aurelien Lefebvre <alkh@mandriva.org>, "
-		"Per Oyvind Karlsen <peroyvind@mandriva.org>",
+		"Per Oyvind Karlsen <peroyvind@mandriva.org>, "
 		"Thierry Vignaud <thierry.vignaud@gmail.com>";
 }
 


### PR DESCRIPTION
There is a wrong comma inside the pk_backend_get_author() string.
It is causing a compiling problem:

    make[4]: Entering directory '/PackageKit/backends/urpmi'
      CC       libpk_backend_urpmi_la-pk-backend-urpmi.lo
    pk-backend-urpmi.c: In function 'pk_backend_get_author':
    pk-backend-urpmi.c:43:48: warning: left-hand operand of comma expression
    has no effect [-Wunused-value]
       "Per Oyvind Karlsen <peroyvind@mandriva.org>",

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>