### PR TITLE
Include whether it's a Source repository

### DIFF
--- a/backends/aptcc/apt-sourceslist.cpp
+++ b/backends/aptcc/apt-sourceslist.cpp
@@ -468,6 +468,10 @@ string SourcesList::SourceRecord::niceName()
         ret += " (" + joinedSections() + ")";
     }
 
+    if(Type & SourcesList::DebSrc) {
+        ret += " Sources";
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
Most repositories will have a "deb" and a "deb-src" variant and
currently the description they offer is the same.