### PR TITLE
aptcc: add support for downgrades as part of updates

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -1260,7 +1260,7 @@ PkgList AptIntf::searchPackageFiles(gchar **values)
     return output;
 }
 
-PkgList AptIntf::getUpdates(PkgList &blocked)
+PkgList AptIntf::getUpdates(PkgList &blocked, PkgList &downgrades)
 {
     PkgList updates;
 
@@ -1282,6 +1282,11 @@ PkgList AptIntf::getUpdates(PkgList &blocked)
             const pkgCache::VerIterator &ver = m_cache->findCandidateVer(pkg);
             if (!ver.end()) {
                 updates.push_back(ver);
+            }
+        } else if (state.Downgrade() == true) {
+            const pkgCache::VerIterator &ver = m_cache->findCandidateVer(pkg);
+            if (!ver.end()) {
+                downgrades.push_back(ver);
             }
         } else if (state.Upgradable() == true &&
                    pkg->CurrentVer != 0 &&

--- a/backends/aptcc/apt-intf.h
+++ b/backends/aptcc/apt-intf.h
@@ -147,7 +147,7 @@ public:
       * Returns a list of all packages that can be updated
       * Pass a PkgList to get the blocked updates as well
       */
-    PkgList getUpdates(PkgList &blocked);
+    PkgList getUpdates(PkgList &blocked, PkgList &downgrades);
 
     /**
      *  Emits a package with the given state

--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -436,10 +436,12 @@ static void backend_get_updates_thread(PkBackendJob *job, GVariant *params, gpoi
     pk_backend_job_set_status(job, PK_STATUS_ENUM_QUERY);
 
     PkgList updates;
+    PkgList downgrades;
     PkgList blocked;
-    updates = apt->getUpdates(blocked);
+    updates = apt->getUpdates(blocked, downgrades);
 
     apt->emitUpdates(updates, filters);
+    apt->emitPackages(downgrades, filters, PK_INFO_ENUM_DOWNGRADING);
     apt->emitPackages(blocked, filters, PK_INFO_ENUM_BLOCKED);
 }
 


### PR DESCRIPTION
users and vendors can "pin" a specific package version after the fact which
allows a specific version to be forced instead whatever the policy would
pick automatically. this sometimes constitutes a downgrade from an already
installed version. within an apt case these downgrades are resolved as
part of full-upgrades, equally within packagekit we'd inform the frontend
of downgrades via package emission. do this when get_updates is run.

the actual upgrade component of this is already implemented for quite a
while. the only thing that was missing is actually notifying the frontend
of the available downgrade.