### PR TITLE
Reflect latest changes in libdnf

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -836,7 +836,7 @@ dnf_utils_run_query_with_newest_filter (DnfSack *sack, HyQuery query)
 	hy_query_free (query_tmp);
 	g_ptr_array_unref (results_tmp);
 
-	g_object_unref (pkgset);
+	dnf_packageset_free(pkgset);
 
 	return results;
 }


### PR DESCRIPTION
Requires: libdnf-0.13.0+

G object DnfPackageSet in libdnf was replaced by c++ class therefore
g_object_unref cannot be used anymore, but the new dnf_packageset_free has to be
used instead.