### PR TITLE
Add additional argument to the dnf_sack_filter_modules() call.

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -800,7 +800,7 @@ dnf_utils_create_sack_for_filters (PkBackendJob *job,
 			return NULL;
 	}
 
-	dnf_sack_filter_modules (sack, dnf_context_get_repos (job_data->context), install_root);
+	dnf_sack_filter_modules (sack, dnf_context_get_repos (job_data->context), install_root, NULL);
 
 	/* save in cache */
 	g_mutex_lock (&priv->sack_mutex);


### PR DESCRIPTION
Libdnf API has changed and the function takes an additional argument: platformModule.
It's set to NULL to trigger platform module auto-detection based on /etc/os-release.