### PR TITLE
command-not-found: If we get uninstalled while running, don't  complain

### DIFF
--- a/contrib/command-not-found/PackageKit.sh.in
+++ b/contrib/command-not-found/PackageKit.sh.in
@@ -21,6 +21,9 @@ command_not_found_handle () {
 
 	# don't run if bash command completion is being run
 	[[ -n ${COMP_CWORD-} ]] && runcnf=0
+	
+	# don't run if we've been uninstalled since the shell was launched
+	[[ ! -x '@LIBEXECDIR@/pk-command-not-found' ]] && runcnf=0
 
 	# run the command, or just print a warning
 	if [ $runcnf -eq 1 ]; then


### PR DESCRIPTION
Check that the client command is executable before executing it,
otherwise you get:

$ foo
-bash: /usr/libexec/pk-command-not-found: No such file or directory

Signed-off-by: Adam Jackson <ajax@redhat.com>