### PR TITLE
aptcc: removing duplicate delete call.

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -506,7 +506,6 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
 
     for (pkgCache::PkgIterator pkg = m_cache->GetPkgCache()->PkgBegin(); !pkg.end(); ++pkg) {
         if (m_cancel) {
-            delete matcher;
             break;
         }
 


### PR DESCRIPTION
This commit removes a duplicate call inside providesCodec() function.
When cancel is active, the loop call tries to delete 'matcher' and after
breaks the loop. But, the function will tries to delete 'matcher' again
at the end.

Signed-off-by: Julio Faracco <jfaracco@br.ibm.com>