### PR TITLE
aptcc: Fix invalid version dereference in AptInf::providesCodec()

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -523,13 +523,14 @@ void AptIntf::providesCodec(PkgList &output, gchar **values)
         // TODO search in updates packages
         // Ignore virtual packages
         pkgCache::VerIterator ver = m_cache->findVer(pkg);
-        arch = string(ver.Arch());
         if (ver.end() == true) {
             ver = m_cache->findCandidateVer(pkg);
-            if (ver.end() == true) {
-                continue;
-            }
         }
+        if (ver.end() == true) {
+            continue;
+        }
+
+        arch = string(ver.Arch());
 
         pkgCache::VerFileIterator vf = ver.FileList();
         pkgRecords::Parser &rec = m_cache->GetPkgRecords()->Lookup(vf);


### PR DESCRIPTION
ver.Arch() was accessed even if ver.End() was true and ver thus
pointed to invalid memory, causing undefined behavior and likely
crashes, such as the Ubuntu bug below.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/1790671