### PR TITLE
docs: Improve the 'using' documentation with a link to API

### DIFF
--- a/docs/api/PackageKit-docs.sgml
+++ b/docs/api/PackageKit-docs.sgml
@@ -51,7 +51,11 @@
     <title>D-Bus API Reference</title>
     <partintro>
       <para>
-        This part documents the D-Bus interface used to access the PackageKit daemon.
+        This part documents the D-Bus interface used to access the
+        PackageKit daemon. The machine-readable specifications are
+        available as XML documents for both the PackageKit interface
+        and the PackageKit.Transaction interface.
+        <xref href="https://github.com/hughsie/PackageKit/blob/master/src/org.freedesktop.PackageKit.xml" scope="external" role="friend" format="html"> XML specification of the org.freedesktop.PackageKit interface</xref>
       </para>
     </partintro>
     <xi:include href="dbus/org.freedesktop.PackageKit.ref.xml"/>

--- a/docs/html/pk-using.html
+++ b/docs/html/pk-using.html
@@ -146,12 +146,11 @@ out:
 
 <h2>Using the raw DBus API:</h2>
 <p>
-Using the DBus methods and signals directly means that no glib or
-gobject dependency is needed, although this means you will have to
-manage the transaction_id multiplexing in any client program.
-This is not difficult, although does require more code than just using
-libpackagekit.
-The latest interface is available in the source tree or <a href="https://github.com/hughsie/PackageKit/blob/master/src/org.freedesktop.PackageKit.xml">on-line</a>.
+Using the <a href="gtk-doc/api-reference.html">PackageKit DBus methods
+and signals</a> directly means that no glib or gobject dependency is
+needed, although this means you will have to manage the transaction_id
+multiplexing in any client program.  This is not difficult, although
+does require more code than just using libpackagekit.
 </p>
 
 <p>Back to the <a href="index.html">main page</a></p>


### PR DESCRIPTION
This contributes to #276. I would like to write documentation in PackageKit-docs.sgml but I have no clue how to create external links in docbook (I tried both `<xref>` and `<link>`).