### PR TITLE
Socket-activated client helper

### DIFF
--- a/backends/aptcc/Makefile.am
+++ b/backends/aptcc/Makefile.am
@@ -2,6 +2,15 @@ AM_CPPFLAGS = \
 	-DDATADIR=\"$(datadir)\"		\
 	-DG_LOG_DOMAIN=\"PackageKit-APTcc\"
 
+PK_GLIB2_LIBS =						\
+	$(top_builddir)/lib/packagekit-glib2/libpackagekit-glib2.la	\
+	$(top_builddir)/lib/packagekit-glib2/libpackagekitprivate.a
+
+
+%: %.in Makefile
+	$(AM_V_GEN)sed -e 's|\@libexecdir\@|$(libexecdir)|' \
+	               -e 's|\@PACKAGEKIT_USER\@|$(PACKAGEKIT_USER)|' $< > $@.tmp && mv $@.tmp $@
+
 plugindir = $(PK_PLUGIN_DIR)
 plugin_LTLIBRARIES = libpk_backend_aptcc.la
 libpk_backend_aptcc_la_SOURCES = pkg-list.cpp \
@@ -35,6 +44,42 @@ libpk_backend_aptcc_la_CPPFLAGS = $(PK_PLUGIN_CFLAGS) \
 
 aptconfdir = ${SYSCONFDIR}/apt/apt.conf.d
 aptconf_DATA = 20packagekit
+
+if HAVE_SYSTEMD
+libexec_PROGRAMS = pk-debconf-helper
+pk_debconf_helper_SOURCES =						\
+	pk-debconf-helper.c
+
+pk_debconf_helper_LDADD =						\
+	$(GLIB_LIBS)					\
+	$(GIO_LIBS)					\
+	$(SYSTEMD_LIBS)					\
+	$(PK_GLIB2_LIBS)
+
+pk_debconf_helper_LDFLAGS =						\
+	$(PIE_LDFLAGS)
+
+pk_debconf_helper_CFLAGS =						\
+	$(WARNINGFLAGS_C)
+pk_debconf_helper_CPPFLAGS =						\
+	$(PIE_CFLAGS)					\
+	$(GLIB_CFLAGS)					\
+	$(GIO_CFLAGS)					\
+	$(SYSTEMD_CFLAGS)				\
+	-DI_KNOW_THE_PACKAGEKIT_GLIB2_API_IS_SUBJECT_TO_CHANGE	\
+	-DPK_COMPILATION				\
+	-DG_LOG_DOMAIN=\"PackageKit\"			\
+	-I$(top_builddir)/lib				\
+	-I$(top_srcdir)					\
+	-I$(top_srcdir)/lib
+systemdservice_in_files =				\
+	pk-debconf-helper.service.in				\
+	pk-debconf-helper.socket.in
+
+systemduserservicedir   = $(systemduserunitdir)
+systemduserservice_DATA = pk-debconf-helper.socket \
+			  pk-debconf-helper.service
+endif
 
 EXTRA_DIST = 20packagekit \
 	     get-distro-upgrade.py \

--- a/backends/aptcc/pk-debconf-helper.c
+++ b/backends/aptcc/pk-debconf-helper.c
@@ -48,7 +48,7 @@ int main(void)
 		return 1;
 	}
 
-	g_timeout_add_seconds(5, exit_loop, NULL);
+	g_timeout_add_seconds(60, exit_loop, NULL);
 
 	g_main_loop_run(main_loop);
 }

--- a/backends/aptcc/pk-debconf-helper.c
+++ b/backends/aptcc/pk-debconf-helper.c
@@ -1,0 +1,54 @@
+#include "config.h"
+#include <stdio.h>
+#include <packagekit-glib2/pk-client.h>
+#include <packagekit-glib2/pk-client-helper.h>
+#include <systemd/sd-daemon.h>
+
+static GMainLoop *main_loop;
+static PkClientHelper *helper;
+
+static gboolean exit_loop(gpointer user_data)
+{
+	g_debug("Checking for active connections");
+	if (!pk_client_helper_is_active(helper)) {
+		g_message("No active connections, exiting");
+		g_main_loop_quit(main_loop);
+	}
+	return TRUE;
+}
+
+int main(void)
+{
+	char **argv = NULL;
+	char **envp = NULL;
+	GSocket *socket = NULL;
+	GError *error = NULL;
+	int fd = -1;
+
+	main_loop = g_main_loop_new(NULL, FALSE);
+	pk_client_create_helper_argv_envp(&argv, &envp);
+
+
+	if (sd_listen_fds(0) != 1) {
+			g_error("No or too many file descriptors received.\n");
+			exit(1);
+	}
+
+	fd = SD_LISTEN_FDS_START + 0;
+	socket = g_socket_new_from_fd(fd, &error);
+
+	if (error != NULL) {
+		g_error("%s\n", error->message);
+		return 1;
+	}
+
+	helper = pk_client_helper_new();
+	if (!pk_client_helper_start_with_socket(helper, socket, argv, envp, &error)) {
+		g_error("%s\n", error->message);
+		return 1;
+	}
+
+	g_timeout_add_seconds(5, exit_loop, NULL);
+
+	g_main_loop_run(main_loop);
+}

--- a/backends/aptcc/pk-debconf-helper.service.in
+++ b/backends/aptcc/pk-debconf-helper.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=debconf communication service
+Requires=pk-debconf-helper.socket
+RefuseManualStart=true
+
+[Service]
+ExecStart=@libexecdir@/pk-debconf-helper

--- a/backends/aptcc/pk-debconf-helper.socket.in
+++ b/backends/aptcc/pk-debconf-helper.socket.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=debconf communication socket
+
+[Socket]
+ListenStream=%t/pk-debconf-socket
+
+[Install]
+WantedBy=sockets.target

--- a/configure.ac
+++ b/configure.ac
@@ -225,8 +225,15 @@ if test x$enable_systemd = xyes; then
 		    [has_systemdsystemunitdir=$with_systemdsystemunitdir],
 		    [has_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
 	AC_SUBST([systemdsystemunitdir], [$has_systemdsystemunitdir])
+	AC_ARG_WITH([systemduserunitdir],
+		    AS_HELP_STRING([--with-systemduserunitdir=DIR], [Directory for systemd user service files]),
+		    [has_systemduserunitdir=$with_systemduserunitdir],
+		    [has_systemduserunitdir=$($PKG_CONFIG --variable=systemduserunitdir systemd)])
+	AC_SUBST([systemduserunitdir], [$has_systemduserunitdir])
+	AC_DEFINE(HAVE_SYSTEMD,1,[Build systemd code])
 fi
 AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$has_systemdsystemunitdir"])
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$has_systemduserunitdir"])
 
 dnl ---------------------------------------------------------------------------
 dnl - Use systemd offline update
@@ -631,6 +638,7 @@ echo "
         Cron scripts:              ${build_cron}
         python3:                   ${enable_python3}
         systemd system unit dir:   ${has_systemdsystemunitdir}
+        systemd user unit dir:     ${has_systemduserunitdir}
         Installing python backend: ${have_python_backend}
         python package dir:        ${with_python_package_dir}
 

--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -135,10 +135,12 @@ pk_client_helper_child_free (PkClientHelperChild *child)
 gboolean
 pk_client_helper_stop (PkClientHelper *client_helper, GError **error)
 {
-	PkClientHelperPrivate *priv = client_helper->priv;
+	PkClientHelperPrivate *priv = NULL;
 
 	g_return_val_if_fail (PK_IS_CLIENT_HELPER (client_helper), FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	priv = client_helper->priv;
 
 	/* make sure started */
 	g_return_val_if_fail (priv->socket_file != NULL, FALSE);
@@ -419,7 +421,7 @@ pk_client_helper_start (PkClientHelper *client_helper,
 	guint i;
 	gboolean use_kde_helper = FALSE;
 	gint fd;
-	PkClientHelperPrivate *priv = client_helper->priv;
+	PkClientHelperPrivate *priv = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GSocketAddress) address = NULL;
 
@@ -428,6 +430,8 @@ pk_client_helper_start (PkClientHelper *client_helper,
 	g_return_val_if_fail (argv != NULL, FALSE);
 	g_return_val_if_fail (socket_filename != NULL, FALSE);
 	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	priv = client_helper->priv;
 
 	/* make sure not been started before */
 	g_return_val_if_fail (priv->argv == NULL, FALSE);

--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -499,6 +499,34 @@ pk_client_helper_start (PkClientHelper *client_helper,
 	return TRUE;
 }
 
+/**
+ * pk_client_helper_is_active:
+ * @client_helper: a valid #PkClientHelper instance
+ *
+ * Return value: TRUE if there is an accepted connection, FALSE
+ *               otherwise.
+ *
+ * Since: 1.1.13
+ */
+gboolean
+pk_client_helper_is_active (PkClientHelper *client_helper)
+{
+	PkClientHelperPrivate *priv;
+
+	g_return_val_if_fail (PK_IS_CLIENT_HELPER (client_helper), FALSE);
+
+	priv = client_helper->priv;
+
+	for (guint i = 0; i < priv->children->len; i++) {
+		PkClientHelperChild *child = g_ptr_array_index (priv->children, i);
+		if (!g_source_is_destroyed (child->socket_channel_source) &&
+		    !g_source_is_destroyed (child->stdout_channel_source))
+			return TRUE;
+	}
+
+	return FALSE;
+}
+
 /*
  * pk_client_helper_class_init:
  **/

--- a/lib/packagekit-glib2/pk-client-helper.c
+++ b/lib/packagekit-glib2/pk-client-helper.c
@@ -420,7 +420,6 @@ pk_client_helper_start (PkClientHelper *client_helper,
 {
 	guint i;
 	gboolean use_kde_helper = FALSE;
-	gint fd;
 	PkClientHelperPrivate *priv = NULL;
 	g_autoptr(GError) error_local = NULL;
 	g_autoptr(GSocketAddress) address = NULL;
@@ -458,10 +457,6 @@ pk_client_helper_start (PkClientHelper *client_helper,
 		}
 	}
 
-	/* cache for actual start */
-	priv->argv = g_strdupv (argv);
-	priv->envp = g_strdupv (envp);
-
 	/* create socket */
 	priv->socket = g_socket_new (G_SOCKET_FAMILY_UNIX, G_SOCKET_TYPE_STREAM, G_SOCKET_PROTOCOL_DEFAULT, error);
 	if (priv->socket == NULL)
@@ -474,6 +469,7 @@ pk_client_helper_start (PkClientHelper *client_helper,
 
 	/* spawn KDE debconf communicator */
 	if (use_kde_helper) {
+		priv->envp = g_strdupv (envp);
 		priv->argv = g_new0 (gchar *, 2);
 		priv->argv[0] = g_strdup ("/usr/bin/debconf-kde-helper");
 		priv->argv[1] = g_strconcat ("--socket-path", "=", socket_filename, NULL);
@@ -490,6 +486,52 @@ pk_client_helper_start (PkClientHelper *client_helper,
 	/* listen to the socket */
 	if (!g_socket_listen (priv->socket, error))
 		return FALSE;
+
+	return pk_client_helper_start_with_socket (client_helper, priv->socket, argv, envp, error);
+}
+
+/**
+ * pk_client_helper_start_with_socket:
+ * @client_helper: a valid #PkClientHelper instance
+ * @socket: the (bound and listening) #GSocket instance to use
+ * @argv: the executable, along with any arguments
+ * @envp: the environment
+ * @error: A #GError or %NULL
+ *
+ * Starts the helper process, by running the helper process and setting
+ * up the socket for use.
+ *
+ * Return value: %TRUE for success
+ *
+ * Since: 1.1.13
+ **/
+gboolean
+pk_client_helper_start_with_socket (PkClientHelper *client_helper,
+				    GSocket *socket,
+				    gchar **argv, gchar **envp,
+				    GError **error)
+{
+	gint fd;
+	PkClientHelperPrivate *priv = NULL;
+	g_autoptr(GError) error_local = NULL;
+	g_autoptr(GSocketAddress) address = NULL;
+
+	g_return_val_if_fail (PK_IS_CLIENT_HELPER (client_helper), FALSE);
+	g_return_val_if_fail (socket != NULL, FALSE);
+	g_return_val_if_fail (argv != NULL, FALSE);
+	g_return_val_if_fail (error == NULL || *error == NULL, FALSE);
+
+	priv = client_helper->priv;
+
+	/* make sure not been started before */
+	g_return_val_if_fail (priv->argv == NULL, FALSE);
+
+	/* cache for actual start */
+	priv->argv = g_strdupv (argv);
+	priv->envp = g_strdupv (envp);
+
+	/* Set the socket */
+	priv->socket = socket;
 
 	/* socket has data */
 	fd = g_socket_get_fd (priv->socket);

--- a/lib/packagekit-glib2/pk-client-helper.h
+++ b/lib/packagekit-glib2/pk-client-helper.h
@@ -71,6 +71,11 @@ gboolean	 pk_client_helper_start			(PkClientHelper	*client_helper,
 							 gchar		**argv,
 							 gchar		**envp,
 							 GError		**error);
+gboolean	 pk_client_helper_start_with_socket	(PkClientHelper	*client_helper,
+							 GSocket	*socket,
+							 gchar		**argv,
+							 gchar		**envp,
+							 GError		**error);
 
 
 gboolean 	pk_client_helper_is_active		(PkClientHelper	*client_helper);

--- a/lib/packagekit-glib2/pk-client-helper.h
+++ b/lib/packagekit-glib2/pk-client-helper.h
@@ -72,6 +72,9 @@ gboolean	 pk_client_helper_start			(PkClientHelper	*client_helper,
 							 gchar		**envp,
 							 GError		**error);
 
+
+gboolean 	pk_client_helper_is_active		(PkClientHelper	*client_helper);
+
 G_END_DECLS
 
 #endif /* __PK_CLIENT_HELPER_H */

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1972,6 +1972,16 @@ pk_client_create_helper_socket (PkClientState *state)
 	if (!ret)
 		return NULL;
 
+	/* This is not a specially handled debian frontend (current terminal or
+	 * the debconf-kde stuff, use a systemd-activated helper if available)
+	 */
+	if (!g_strv_contains ((const gchar * const *) envp, "DEBIAN_FRONTEND=kde") &&
+	    !g_strv_contains ((const gchar * const *) envp, "DEBIAN_FRONTEND=dialog")) {
+		g_autofree gchar *existing_socket_filename = g_build_filename (g_get_user_runtime_dir (), "pk-debconf-socket", NULL);
+		if (g_file_test (existing_socket_filename, G_FILE_TEST_EXISTS))
+			return g_strdup_printf ("frontend-socket=%s", existing_socket_filename);
+	}
+
 	/* create object */
 	state->client_helper = pk_client_helper_new ();
 

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -1889,9 +1889,8 @@ pk_client_create_helper_argv_envp_test (PkClientState *state,
 /*
  * pk_client_create_helper_argv_envp:
  **/
-static gboolean
-pk_client_create_helper_argv_envp (PkClientState *state,
-				   gchar ***argv,
+gboolean
+pk_client_create_helper_argv_envp (gchar ***argv,
 				   gchar ***envp_out)
 {
 	const gchar *dialog = NULL;
@@ -1965,8 +1964,7 @@ pk_client_create_helper_socket (PkClientState *state)
 
 	/* either the self test failed, or we're not in self test */
 	if (!ret) {
-		ret = pk_client_create_helper_argv_envp (state,
-							 &argv,
+		ret = pk_client_create_helper_argv_envp (&argv,
 							 &envp);
 	}
 

--- a/lib/packagekit-glib2/pk-client.h
+++ b/lib/packagekit-glib2/pk-client.h
@@ -412,6 +412,9 @@ void		 pk_client_get_progress_async 		(PkClient		*client,
 							 GAsyncReadyCallback	 callback_ready,
 							 gpointer		 user_data);
 
+gboolean	pk_client_create_helper_argv_envp	(gchar 			***argv,
+							 gchar			***envp_out);
+
 /* getters and setters */
 void		 pk_client_set_locale			(PkClient		*client,
 							 const gchar		*locale);


### PR DESCRIPTION
Introduce support for a socket-activated client helper for aptcc. This solves a problem where the current client helpers are children of the client starting the transaction and potentially bound to the client's lifetime; so if the client is exited early, while the transaction is still running, no debconf prompts would be shown.

A socket-activated helper solves this problem by making sure we only ever run one helper as a systemd user service.

This change is incompatible with the debconf-kde hacks, I'm not sure what to do about those yet.