### PR TITLE
dnf: Avoid offline updates cache growing unchecked

### DIFF
--- a/src/pk-shared.h
+++ b/src/pk-shared.h
@@ -28,6 +28,8 @@
 G_BEGIN_DECLS
 
 gboolean	 pk_directory_remove_contents		(const gchar	*directory);
+GPtrArray	*pk_directory_find_files_with_suffix	(const gchar	*directory,
+							 const gchar	*filename_suffix);
 guint		 pk_strlen				(const gchar	*text,
 							 guint		 len)
 							 G_GNUC_WARN_UNUSED_RESULT;


### PR DESCRIPTION
If a user ignores gnome-software install notifications and never applies
offline updates, we would keep downloading new rpms and never delete the
old ones from the cache.

This commit fixes this.

The cache cleanup strategy is to wait until we've finished downloading a
new offline update, and then clean up any rpms from the cache that the
newly downloaded update doesn't need.

https://bugzilla.redhat.com/show_bug.cgi?id=1306992