### PR TITLE
aptcc: Ignore non-fatal warnings on refresh-cache

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2073,9 +2073,9 @@ void AptIntf::refreshCache()
     }
 
     // missing repo gpg signature would appear here
-    if (_error->PendingError() == false && _error->empty() == false) {
-        // TODO this shouldn't
-        show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE);
+    // TODO check what other errors could remain here and ensure the right error code is emitted for each
+    if (_error->empty() == false) {
+        show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE, true, true);
     }
 }
 

--- a/backends/aptcc/apt-messages.cpp
+++ b/backends/aptcc/apt-messages.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-bool show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
+bool show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify, bool ignoreWarnings)
 {
     stringstream errors;
 
@@ -42,13 +42,17 @@ bool show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
             // TODO this should emit the regular
             // PK_ERROR_ENUM_CANNOT_FETCH_SOURCES but do not fail the
             // last-time-update
-            //! messages << "E: " << Err << endl;
-        } else {
-            if (Type == true) {
-                errors << "E: " << Err << endl;
-            } else {
-                errors << "W: " << Err << endl;
-            }
+            continue;
+        }
+
+        if ((errModify) && (Err.find("does not have a Release file") != string::npos)) {
+            continue;
+        }
+
+        if (Type == true) {
+            errors << "E: " << Err << endl;
+        } else if (!ignoreWarnings) {
+            errors << "W: " << Err << endl;
         }
     }
 

--- a/backends/aptcc/apt-messages.cpp
+++ b/backends/aptcc/apt-messages.cpp
@@ -37,6 +37,10 @@ void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify, bool 
     while (_error->empty() == false) {
         bool Type = _error->PopMessage(Err);
 
+        // Log all apt warnings/errors to journal as we may discard them here, but they may
+        // still be useful
+        g_warning("%s", Err.c_str());
+
         // Ugly workaround to demote the "repo not found" error message to a simple message
         if ((errModify) && (Err.find("404  Not Found") != string::npos)) {
             // TODO this should emit the regular

--- a/backends/aptcc/apt-messages.cpp
+++ b/backends/aptcc/apt-messages.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
+void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify, bool ignoreWarnings)
 {
     stringstream errors;
 

--- a/backends/aptcc/apt-messages.h
+++ b/backends/aptcc/apt-messages.h
@@ -33,6 +33,7 @@
  */
 bool show_errors(PkBackendJob *job,
                  PkErrorEnum errorCode = PK_ERROR_ENUM_UNKNOWN,
-                 bool errModify = false);
+                 bool errModify = false,
+                 bool ignoreWarnings = false);
 
 #endif // AAPT_BACKEND_MESSAGES_H


### PR DESCRIPTION
Because of these few lines of code:

```
if (_error->PendingError() == false && _error->empty() == false) {
        // TODO this shouldn't
        show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE);
```

If warnings (but no errors) had been emitted by apt, they'd be turned into a GPG failure which causes a couple of issues:

- Any non-fatal issues during `refresh-cache` would cause the task to report failure. For example, misconfigured/unreachable repositories or even repositories without appstream information (when it was expected) were causing the whole task to report failure.
- Emitting GPG_FAILURE in a non-interactive context causes the task to automatically retry with untrusted software allowed. This fails, because PackageKit still inteprets any warnings/errors that come out of apt as GPG failures, so this gets stuck in an infinite loop.

However, since real GPG failures are reported as errors, not warnings by apt, it's not necessary to do it this way.

This PR ignores all of the non-error items from the `_error` list as they were considered non-fatal by the apt refresh. The rest are processed in `show_errors` which already had some provisions for ignoring 404 errors, which I've added another check to about release files, which usually follows a 404.

While this doesn't cover all the possible cases, it covers the common misconfigured repository issues (usually caused by wrong release name after system upgrade) and temporary issues with mirrors and just silently ignores these issues like apt on the command line does. I'll raise a separate issue about the GPG failure infinite loop.