### PR TITLE
transaction: Return directly when its state is going backwards

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -760,6 +760,7 @@ pk_transaction_set_state (PkTransaction *transaction, PkTransactionState state)
 		g_warning ("cannot set %s, as already %s",
 			   pk_transaction_state_to_string (state),
 			   pk_transaction_state_to_string (priv->state));
+		return;
 	}
 
 	g_debug ("transaction now %s", pk_transaction_state_to_string (state));


### PR DESCRIPTION
We should return directly while failing to set transaction’s state
because it’s going backwards. That’s exactly what Pk did previously.

Fixes 2807cbf8