### PR TITLE
zypp: Switch to doUpgrade solver when required by distribution

### DIFF
--- a/backends/zypp/pk-backend-zypp.cpp
+++ b/backends/zypp/pk-backend-zypp.cpp
@@ -3297,6 +3297,14 @@ backend_update_packages_thread (PkBackendJob *job, GVariant *params, gpointer us
 	ResPool pool = zypp_build_pool (zypp, TRUE);
 	PkRestartEnum restart = PK_RESTART_ENUM_NONE;
 
+	for ( const PoolItem & pi : pool.byKind<Product>() ) {
+		static const Capability indicator( "product-update()", Rel::EQ, "dup" );
+		if ( pi->asKind<Product>()->referencePackage().provides().matches( indicator ) ) {
+			zypp->resolver()->setUpgradeMode(TRUE);
+			break;
+		}
+	}
+
 	PoolStatusSaver saver;
 
 	for (guint i = 0; package_ids[i]; i++) {


### PR DESCRIPTION
Not the prettiest solution, but since zypper checks for `dup` argument the same way when notifying the user about proper update command, this is the most distro-agnostic way I could do this.