### PR TITLE
aptcc: Use correct return type in show_errors()

### DIFF
--- a/backends/aptcc/apt-messages.cpp
+++ b/backends/aptcc/apt-messages.cpp
@@ -29,7 +29,7 @@
 
 using namespace std;
 
-bool show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
+void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
 {
     stringstream errors;
 

--- a/backends/aptcc/apt-messages.h
+++ b/backends/aptcc/apt-messages.h
@@ -31,7 +31,7 @@
 /**
  * Call the Packagekit error dialog
  */
-bool show_errors(PkBackendJob *job,
+void show_errors(PkBackendJob *job,
                  PkErrorEnum errorCode = PK_ERROR_ENUM_UNKNOWN,
                  bool errModify = false);
 


### PR DESCRIPTION
The aptcc `show_errors()` function doesn't return anything, but was declared with a `bool` return type. This PR changes the function to a `void` return type. The `bool` that was supposedly returned by the function wasn't used anywhere.

I found this issue when investigating [this crash][1], which seems to be a problem with temporary objects being destructed in wrong order in an optimized build. Fixing the return type of `show_errors()` also seems to have fixed this crash. I'm suspecting the optimizer got confused by the invalid return and generated invalid code, but I can't really be sure this is really the root cause for the crash.

But be that as it may, fixing the return type of the `show_error()` function makes the code more correct in any case.

 [1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911731