### PR TITLE
aptcc: also generate a repo detail when a download happened (and finished)

### DIFF
--- a/backends/aptcc/acqpkitstatus.cpp
+++ b/backends/aptcc/acqpkitstatus.cpp
@@ -79,6 +79,13 @@ void AcqPackageKitStatus::Fetch(pkgAcquire::ItemDesc &Itm)
 /* We don't display anything... */
 void AcqPackageKitStatus::Done(pkgAcquire::ItemDesc &Itm)
 {
+    PkRoleEnum role = pk_backend_job_get_role(m_job);
+    if (role == PK_ROLE_ENUM_REFRESH_CACHE) {
+        pk_backend_job_repo_detail(m_job,
+                                   "",
+                                   Itm.Description.c_str(),
+                                   true);
+    }
     // Download completed
     updateStatus(Itm, 100);
 }


### PR DESCRIPTION
the previous code paths only covered

- Hit (aka the server responded with not-modified or somesuch code)
- Ign (aka the server 404s or somesuch indicating the repo doesn't exist)

but ignored

- Get (aka code 200 and data was downloaded)

this resulted in repos which actually had updates available (hence the
file change and need for download) not being reported in `pkcon refresh`
output at all.

::Done acquire updates now also cause a repo detail to get added so
pkcon can show the repo as [enabled] when running `pkcon refresh`.