### PR TITLE
offline update: Use new plymouth "system-upgrade" and "reboot" modes

### DIFF
--- a/client/pk-offline-update.c
+++ b/client/pk-offline-update.c
@@ -188,7 +188,11 @@ pk_offline_update_reboot (void)
 
 	/* reboot using systemd */
 	sd_journal_print (LOG_INFO, "rebooting");
+#ifdef PLYMOUTH_0_9_5
+	pk_offline_update_set_plymouth_mode ("reboot");
+#else
 	pk_offline_update_set_plymouth_mode ("shutdown");
+#endif
 	/* TRANSLATORS: we've finished doing offline updates */
 	pk_offline_update_set_plymouth_msg (_("Rebooting after installing updates…"));
 	connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, &error);
@@ -371,6 +375,7 @@ pk_offline_update_do_update (PkTask *task, PkProgressBar *progressbar, GError **
 		return FALSE;
 	}
 
+	pk_offline_update_set_plymouth_mode ("updates");
 	/* TRANSLATORS: we've started doing offline updates */
 	pk_offline_update_set_plymouth_msg (_("Installing updates; this could take a while..."));
 	pk_offline_update_write_dummy_results ();
@@ -403,6 +408,11 @@ pk_offline_update_do_upgrade (PkTask *task, PkProgressBar *progressbar, GError *
 	        return FALSE;
 	}
 
+#ifdef PLYMOUTH_0_9_5
+	pk_offline_update_set_plymouth_mode ("system-upgrade");
+#else
+	pk_offline_update_set_plymouth_mode ("updates");
+#endif
 	/* TRANSLATORS: we've started doing offline system upgrade */
 	pk_offline_update_set_plymouth_msg (_("Installing system upgrade; this could take a while..."));
 	pk_offline_update_write_dummy_results ();
@@ -485,7 +495,6 @@ main (int argc, char *argv[])
 
 	task = pk_task_new ();
 	pk_client_set_interactive (PK_CLIENT (task), FALSE);
-	pk_offline_update_set_plymouth_mode ("updates");
 
 	if (g_strcmp0 (link, PK_OFFLINE_PREPARED_UPGRADE_FILENAME) == 0 &&
 	    g_file_test (PK_OFFLINE_PREPARED_UPGRADE_FILENAME, G_FILE_TEST_EXISTS)) {

--- a/configure.ac
+++ b/configure.ac
@@ -190,6 +190,14 @@ AS_IF([test "$have_polkit_0_114" = "yes"], [
 	          [Define as 1 if you have polkit >= 0.114])
 ])
 
+# 0.9.5 introduced new boot splash modes
+PKG_CHECK_MODULES([PLYMOUTH_0_9_5], [ply-boot-client >= 0.9.5],
+                  [have_plymouth_0_9_5=yes], [have_plymouth_0_9_5=no])
+AS_IF([test "$have_plymouth_0_9_5" = "yes"], [
+	AC_DEFINE([PLYMOUTH_0_9_5],[1],
+	          [Define as 1 if you have plymouth >= 0.9.5])
+])
+
 # Avoid g_simple_async_result deprecation warnings in glib 2.46+
 AC_DEFINE(GLIB_VERSION_MIN_REQUIRED, GLIB_VERSION_2_44, [minimum glib version])
 


### PR DESCRIPTION
These landed in plymouth git yesterday to implement
https://wiki.gnome.org/Design/OS/BootProgress

Using the new API conditionally is tricky as it's command line API;
enterprise distros that don't have new enough plymouth should probably
just revert this commit.