### PR TITLE
aptcc: Implement frontend-locking

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2384,7 +2384,7 @@ bool AptIntf::installPackages(PkBitfield flags)
 
     // we could try to see if this is the case
     setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", 1);
-    _system->UnLock();
+    _system->UnLockInner();
 
     pkgPackageManager::OrderResult res;
     res = PM->DoInstallPreFork();
@@ -2482,6 +2482,7 @@ bool AptIntf::installPackages(PkBitfield flags)
     close(readFromChildFD[0]);
     close(readFromChildFD[1]);
     close(pty_master);
+    _system->LockInner();
 
     cout << "Parent finished..." << endl;
     return true;

--- a/configure.ac
+++ b/configure.ac
@@ -462,6 +462,12 @@ if test x$enable_aptcc = xyes; then
 			  AC_MSG_RESULT([yes]),
 			  AC_MSG_FAILURE([need libapt-pkg 1.1 or later]))
 
+	AC_MSG_CHECKING([whether apt has frontend locking / is at least version 1.7])
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <apt-pkg/pkgsystem.h>]],
+					  [[_system->LockInner();]])],
+			  AC_MSG_RESULT([yes]),
+			  AC_MSG_FAILURE([need libapt-pkg 1.7 or later - or backported frontend locking]))
+
 	AC_MSG_CHECKING([whether apt supports ddtp])
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <apt-pkg/pkgcache.h>]],
 					  [[pkgCache::DescIterator d;]])],


### PR DESCRIPTION
This implements APT frontend locking, which prevents other programs
from stealing the dpkg lock in race conditions where apt(cc) has to
release the lock in order to run dpkg.

Bug-Ubuntu: https://bugs.launchpad.net/bugs/1795614