### PR TITLE
aptcc: Only report errors if there are errors

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2153,9 +2153,6 @@ void AptIntf::refreshCache()
     if (m_cache->BuildCaches() == false) {
         return;
     }
-
-    // TODO check what other errors could remain here and ensure the right error code is emitted for each
-    show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE, true);
 }
 
 void AptIntf::markAutoInstalled(const PkgList &pkgs)

--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -2154,11 +2154,8 @@ void AptIntf::refreshCache()
         return;
     }
 
-    // missing repo gpg signature would appear here
-    if (_error->PendingError() == false && _error->empty() == false) {
-        // TODO this shouldn't
-        show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE);
-    }
+    // TODO check what other errors could remain here and ensure the right error code is emitted for each
+    show_errors(m_job, PK_ERROR_ENUM_GPG_FAILURE, true);
 }
 
 void AptIntf::markAutoInstalled(const PkgList &pkgs)

--- a/backends/aptcc/apt-messages.cpp
+++ b/backends/aptcc/apt-messages.cpp
@@ -32,10 +32,13 @@ using namespace std;
 void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
 {
     stringstream errors;
+    int errorCount = 0;
 
     string Err;
     while (_error->empty() == false) {
         bool Type = _error->PopMessage(Err);
+
+        g_warning("%s", Err.c_str());
 
         // Ugly workaround to demote the "repo not found" error message to a simple message
         if ((errModify) && (Err.find("404  Not Found") != string::npos)) {
@@ -43,16 +46,18 @@ void show_errors(PkBackendJob *job, PkErrorEnum errorCode, bool errModify)
             // PK_ERROR_ENUM_CANNOT_FETCH_SOURCES but do not fail the
             // last-time-update
             //! messages << "E: " << Err << endl;
+            continue;
+        }
+
+        if (Type == true) {
+            errors << "E: " << Err << endl;
+            errorCount++;
         } else {
-            if (Type == true) {
-                errors << "E: " << Err << endl;
-            } else {
-                errors << "W: " << Err << endl;
-            }
+            errors << "W: " << Err << endl;
         }
     }
 
-    if (!errors.str().empty()) {
+    if (errorCount > 0) {
         pk_backend_job_error_code(job,
                                   errorCode,
                                   "%s",


### PR DESCRIPTION
Previously aptcc would report some warnings as errors. This way,
it will drop any warning if there is no error. This matches the
behavior of python-apt.

As a bonus, we also log the entire message as a warning to the
journal.

This obsoletes #295