### PR TITLE
dnf: Replace armv5tl with aarch64 for Mageia repo configuration vendor

### DIFF
--- a/backends/dnf/dnf-backend-vendor-mageia.c
+++ b/backends/dnf/dnf-backend-vendor-mageia.c
@@ -38,8 +38,8 @@ dnf_validate_supported_repo (const gchar *id)
 
 	const gchar *valid_arch[] = { "x86_64",
 				      "i586",
+				      "aarch64",
 				      "armv7hl",
-				      "armv5tl",
 				      NULL };
 
 	const gchar *valid[] = { "mageia",


### PR DESCRIPTION
With Mageia 7, armv5tl has been removed and aarch64 has been introduced.
Thus, we want to make sure aarch64 repositories are marked as supported
and remove armv5tl from the supported arches list.