### PR TITLE
aptcc: improve support of obsoletes during updates

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -852,10 +852,23 @@ void AptIntf::emitUpdateDetail(const pkgCache::VerIterator &candver)
     bugzilla_urls = getBugzillaUrls(changelog);
     cve_urls = getCVEUrls(changelog);
 
+    GPtrArray *obsoletes = g_ptr_array_new();
+
+    for (auto deps = candver.DependsList(); not deps.end(); ++deps)
+    {
+        if (deps->Type == pkgCache::Dep::Obsoletes)
+        {
+            g_ptr_array_add(obsoletes, (void*) deps.TargetPkg().Name());
+        }
+    }
+
+    // NULL terminate
+    g_ptr_array_add(obsoletes, NULL);
+
     pk_backend_job_update_detail(m_job,
                                  package_id,
                                  updates,//const gchar *updates
-                                 NULL,//const gchar *obsoletes
+                                 (gchar **) obsoletes->pdata,//const gchar *obsoletes
                                  NULL,//const gchar *vendor_url
                                  (gchar **) bugzilla_urls->pdata,// gchar **bugzilla_urls
                                  (gchar **) cve_urls->pdata,// gchar **cve_urls
@@ -869,6 +882,7 @@ void AptIntf::emitUpdateDetail(const pkgCache::VerIterator &candver)
 
     g_free(package_id);
     g_strfreev(updates);
+    g_ptr_array_unref(obsoletes);
     g_ptr_array_unref(bugzilla_urls);
     g_ptr_array_unref(cve_urls);
 }

--- a/backends/aptcc/apt-intf.h
+++ b/backends/aptcc/apt-intf.h
@@ -147,7 +147,7 @@ public:
       * Returns a list of all packages that can be updated
       * Pass a PkgList to get the blocked updates as well
       */
-    PkgList getUpdates(PkgList &blocked, PkgList &downgrades);
+    PkgList getUpdates(PkgList &blocked, PkgList &downgrades, PkgList &installs, PkgList &removals, PkgList &obsoleted);
 
     /**
      *  Emits a package with the given state

--- a/backends/aptcc/pk-backend-aptcc.cpp
+++ b/backends/aptcc/pk-backend-aptcc.cpp
@@ -384,11 +384,17 @@ static void backend_get_updates_thread(PkBackendJob *job, GVariant *params, gpoi
     pk_backend_job_set_status(job, PK_STATUS_ENUM_QUERY);
 
     PkgList updates;
+    PkgList installs;
+    PkgList removals;
+    PkgList obsoleted;
     PkgList downgrades;
     PkgList blocked;
-    updates = apt->getUpdates(blocked, downgrades);
+    updates = apt->getUpdates(blocked, downgrades, installs, removals, obsoleted);
 
     apt->emitUpdates(updates, filters);
+    apt->emitPackages(installs, filters, PK_INFO_ENUM_INSTALLING);
+    apt->emitPackages(removals, filters, PK_INFO_ENUM_REMOVING);
+    apt->emitPackages(obsoleted, filters, PK_INFO_ENUM_OBSOLETING);
     apt->emitPackages(downgrades, filters, PK_INFO_ENUM_DOWNGRADING);
     apt->emitPackages(blocked, filters, PK_INFO_ENUM_BLOCKED);
 }

--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -1112,6 +1112,13 @@ pk_console_update_packages (PkConsoleCtx *ctx, gchar **packages, GError **error)
 }
 
 static gboolean
+pk_console_update_system_filter_helper (PkPackage *package, gpointer user_data)
+{
+	PkInfoEnum package_enum = pk_package_get_info (package);
+	return (package_enum != PK_INFO_ENUM_OBSOLETING && package_enum != PK_INFO_ENUM_REMOVING);
+}
+
+static gboolean
 pk_console_update_system (PkConsoleCtx *ctx, GError **error)
 {
 	g_autoptr(PkPackageSack) sack = NULL;
@@ -1130,6 +1137,7 @@ pk_console_update_system (PkConsoleCtx *ctx, GError **error)
 
 	/* do the async action */
 	sack = pk_results_get_package_sack (results);
+	pk_package_sack_remove_by_filter (sack, &pk_console_update_system_filter_helper, NULL);
 	package_ids = pk_package_sack_get_ids (sack);
 	if (g_strv_length (package_ids) == 0) {
 		pk_progress_bar_end (ctx->progressbar);


### PR DESCRIPTION
Output of 'pkcon get-updates' command is changed to reflect more closely what would actually be updated, installed, removed or obsoleted during update, but it may require to modify users of this command to not just install everything from output of this command, including removed and obsoleted packages, similarly to how 'pkcon update' is updated in these changes.