### PR TITLE
update for pacman 5.2 API change

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -40,7 +40,6 @@ typedef struct
 {
 	 gboolean		 checkspace, color, ilovecandy, totaldl,
 				 usesyslog, verbosepkglists;
-	 gdouble		 deltaratio;
 
 	 gchar			*arch, *cleanmethod, *dbpath, *gpgdir, *logfile,
 				*root, *xfercmd;
@@ -65,7 +64,6 @@ pk_alpm_config_new (PkBackend *backend)
 {
 	PkAlpmConfig *config = g_new0 (PkAlpmConfig, 1);
 	config->backend = backend;
-	config->deltaratio = 0.0;
 
 	config->xrepo = g_regex_new ("\\$repo", 0, 0, NULL);
 	config->xarch = g_regex_new ("\\$arch", 0, 0, NULL);
@@ -148,14 +146,6 @@ pk_alpm_config_set_totaldl (PkAlpmConfig *config)
 }
 
 static void
-pk_alpm_config_set_usedelta (PkAlpmConfig *config)
-{
-	g_return_if_fail (config != NULL);
-
-	config->deltaratio = 0.7;
-}
-
-static void
 pk_alpm_config_set_usesyslog (PkAlpmConfig *config)
 {
 	g_return_if_fail (config != NULL);
@@ -183,7 +173,6 @@ static const PkAlpmConfigBoolean pk_alpm_config_boolean_options[] = {
 	{ "Color", pk_alpm_config_set_color },
 	{ "ILoveCandy", pk_alpm_config_set_ilovecandy },
 	{ "TotalDownload", pk_alpm_config_set_totaldl },
-	{ "UseDelta", pk_alpm_config_set_usedelta },
 	{ "UseSyslog", pk_alpm_config_set_usesyslog },
 	{ "VerbosePkgLists", pk_alpm_config_set_verbosepkglists },
 	{ NULL, NULL }
@@ -293,22 +282,6 @@ pk_alpm_config_set_root (PkAlpmConfig *config, const gchar *path)
 }
 
 static void
-pk_alpm_config_set_deltaratio (PkAlpmConfig *config, const gchar *number)
-{
-	gdouble ratio;
-	gchar *endptr;
-
-	g_return_if_fail (config != NULL);
-	g_return_if_fail (number != NULL);
-
-	ratio = g_ascii_strtod (number, &endptr);
-	/* this ignores invalid values whereas pacman reports an error */
-	if (*endptr == '\0' && 0.0 <= ratio && ratio <= 2.0) {
-		config->deltaratio = ratio;
-	}
-}
-
-static void
 pk_alpm_config_set_xfercmd (PkAlpmConfig *config, const gchar *command)
 {
 	g_return_if_fail (config != NULL);
@@ -333,7 +306,6 @@ static const PkAlpmConfigString pk_alpm_config_string_options[] = {
 	{ "GPGDir", pk_alpm_config_set_gpgdir },
 	{ "LogFile", pk_alpm_config_set_logfile },
 	{ "RootDir", pk_alpm_config_set_root },
-	{ "UseDelta", pk_alpm_config_set_deltaratio },
 	{ "XferCommand", pk_alpm_config_set_xfercmd },
 	{ NULL, NULL }
 };
@@ -947,7 +919,6 @@ pk_alpm_config_configure_alpm (PkBackend *backend, PkAlpmConfig *config, GError 
 	alpm_option_set_checkspace (handle, config->checkspace);
 	alpm_option_set_usesyslog (handle, config->usesyslog);
 	alpm_option_set_arch (handle, config->arch);
-	alpm_option_set_deltaratio (handle, config->deltaratio);
 
 	/* backend takes ownership */
 	g_free (xfercmd);

--- a/backends/alpm/pk-alpm-error.c
+++ b/backends/alpm/pk-alpm-error.c
@@ -111,7 +111,6 @@ pk_alpm_error_emit (PkBackendJob *job, GError *error)
 	case ALPM_ERR_PKG_INVALID:
 	case ALPM_ERR_PKG_OPEN:
 	case ALPM_ERR_PKG_INVALID_NAME:
-	case ALPM_ERR_DLT_INVALID:
 		code = PK_ERROR_ENUM_INVALID_PACKAGE_FILE;
 		break;
 	case ALPM_ERR_PKG_INVALID_CHECKSUM:
@@ -125,9 +124,6 @@ pk_alpm_error_emit (PkBackendJob *job, GError *error)
 		break;
 	case ALPM_ERR_SIG_MISSING:
 		code = PK_ERROR_ENUM_MISSING_GPG_SIGNATURE;
-		break;
-	case ALPM_ERR_DLT_PATCHFAILED:
-		code = PK_ERROR_ENUM_PACKAGE_FAILED_TO_BUILD;
 		break;
 	case ALPM_ERR_UNSATISFIED_DEPS:
 		code = PK_ERROR_ENUM_DEP_RESOLUTION_FAILED;

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -62,15 +62,6 @@ pk_alpm_pkg_has_basename (PkBackend *backend, alpm_pkg_t *pkg, const gchar *base
 	if (g_strcmp0 (alpm_pkg_get_filename (pkg), basename) == 0)
 		return TRUE;
 
-	if (alpm_option_get_deltaratio (priv->alpm) == 0.0)
-		return FALSE;
-
-	for (i = alpm_pkg_get_deltas (pkg); i != NULL; i = i->next) {
-		alpm_delta_t *delta = (alpm_delta_t *) i->data;
-		if (g_strcmp0 (delta->delta, basename) == 0)
-			return TRUE;
-	}
-
 	return FALSE;
 }
 
@@ -647,7 +638,6 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 	case ALPM_EVENT_RESOLVEDEPS_START:
 		pk_alpm_transaction_dep_resolve (job);
 		break;
-	case ALPM_EVENT_DELTA_INTEGRITY_START:
 	case ALPM_EVENT_DISKSPACE_START:
 	case ALPM_EVENT_FILECONFLICTS_START:
 	case ALPM_EVENT_INTERCONFLICTS_START:
@@ -700,10 +690,6 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 	case ALPM_EVENT_LOAD_START:
 		pk_alpm_transaction_setup (job);
 		break;
-	case ALPM_EVENT_DELTA_PATCHES_START:
-	case ALPM_EVENT_DELTA_PATCH_START:
-		pk_alpm_transaction_repackaging (job);
-		break;
 	case ALPM_EVENT_SCRIPTLET_INFO:
 		pk_alpm_transaction_output (((alpm_event_scriptlet_info_t *) event)->line);
 		break;
@@ -726,10 +712,6 @@ pk_alpm_transaction_event_cb (alpm_event_t *event)
 		break;
 	case ALPM_EVENT_CHECKDEPS_DONE:
 	case ALPM_EVENT_DATABASE_MISSING:
-	case ALPM_EVENT_DELTA_INTEGRITY_DONE:
-	case ALPM_EVENT_DELTA_PATCH_DONE:
-	case ALPM_EVENT_DELTA_PATCHES_DONE:
-	case ALPM_EVENT_DELTA_PATCH_FAILED:
 	case ALPM_EVENT_DISKSPACE_DONE:
 	case ALPM_EVENT_FILECONFLICTS_DONE:
 	case ALPM_EVENT_HOOK_DONE:
@@ -1072,7 +1054,6 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 		alpm_list_free (data);
 		break;
 	case ALPM_ERR_PKG_INVALID:
-	case ALPM_ERR_DLT_INVALID:
 		prefix = pk_alpm_string_build_list (data);
 		alpm_list_free (data);
 		break;

--- a/configure.ac
+++ b/configure.ac
@@ -498,7 +498,7 @@ if test x$enable_aptcc = xyes; then
 fi
 
 if test x$enable_alpm = xyes; then
-	PKG_CHECK_MODULES(ALPM, libalpm >= 10.0.0)
+	PKG_CHECK_MODULES(ALPM, libalpm >= 12.0.0)
 fi
 
 if test x$enable_poldek = xyes; then


### PR DESCRIPTION
With the release of pacman 5.2 we have an API change with upstream commit c0e9be79:

  commit c0e9be7973be6c81b22fde91516fb8991e7bb07b
  Author: Allan McRae <allan@archlinux.org>
  Date:   Sat Mar 2 18:57:20 2019 +1000

    Remove support for deltas from libalpm