### PR TITLE
dnf: Reset libgit2 module when upgrading to F31

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -3435,6 +3435,17 @@ pk_backend_upgrade_system_thread (PkBackendJob *job, GVariant *params, gpointer 
 	/* set the installonly limit one higher than usual to avoid removing any kernels during system upgrades */
 	dnf_sack_set_installonly_limit (sack, dnf_context_get_installonly_limit (job_data->context) + 1);
 
+	/* reset libgit2 module when upgrading to F31: https://bugzilla.redhat.com/show_bug.cgi?id=1762751 */
+	if (g_strcmp0 (release_ver, "31") == 0) {
+		const gchar *reset_modules[] = { "libgit2", NULL };
+		g_autoptr(GError) error_local = NULL;
+
+		g_debug ("resetting libgit2 module");
+		if (!dnf_context_reset_modules (job_data->context, sack, reset_modules, &error_local)) {
+			g_warning ("failed to reset libgit2 module: %s", error_local->message);
+		}
+	}
+
 	/* done */
 	if (!dnf_state_done (job_data->state, &error)) {
 		pk_backend_job_error_code (job, error->code, "%s", error->message);


### PR DESCRIPTION
Work around a modularity upgrade bug by resetting the libgit2 module
when upgrading to F31. This depends on new libdnf API from
https://github.com/rpm-software-management/libdnf/pull/822

https://bugzilla.redhat.com/show_bug.cgi?id=1762751