### PR TITLE
command-not-found: Remove spurious ellipsis...

### DIFF
--- a/contrib/command-not-found/pk-command-not-found.c
+++ b/contrib/command-not-found/pk-command-not-found.c
@@ -775,7 +775,7 @@ main (int argc, char *argv[])
 	/* TRANSLATORS: the prefix of all the output telling the user
 	 * why it's not executing. NOTE: this is lowercase to mimic
 	 * the style of bash itself -- apologies */
-	g_printerr ("%s: %s: %s...\n", shell, argv[1], _("command not found"));
+	g_printerr ("%s: %s: %s\n", shell, argv[1], _("command not found"));
 
 	/* ignore one char mistakes */
 	if (len < 2)


### PR DESCRIPTION
`bash` does not output an ellipsis here...so there’s no reason for `command-not-found` to do so...it was actually kind of annoying...