### PR TITLE
dnf: Condition the libgit2 module reset hack to the Fedora vendor

### DIFF
--- a/backends/dnf/pk-backend-dnf.c
+++ b/backends/dnf/pk-backend-dnf.c
@@ -3435,6 +3435,7 @@ pk_backend_upgrade_system_thread (PkBackendJob *job, GVariant *params, gpointer 
 	/* set the installonly limit one higher than usual to avoid removing any kernels during system upgrades */
 	dnf_sack_set_installonly_limit (sack, dnf_context_get_installonly_limit (job_data->context) + 1);
 
+	#if defined(__dnf_vendor_fedora__)
 	/* reset libgit2 module when upgrading to F31: https://bugzilla.redhat.com/show_bug.cgi?id=1762751 */
 	if (g_strcmp0 (release_ver, "31") == 0) {
 		const gchar *reset_modules[] = { "libgit2", NULL };
@@ -3445,6 +3446,7 @@ pk_backend_upgrade_system_thread (PkBackendJob *job, GVariant *params, gpointer 
 			g_warning ("failed to reset libgit2 module: %s", error_local->message);
 		}
 	}
+	#endif
 
 	/* done */
 	if (!dnf_state_done (job_data->state, &error)) {

--- a/configure.ac
+++ b/configure.ac
@@ -433,6 +433,7 @@ if test x$enable_dnf = xyes; then
 		with_dnf_vendor="fedora"
 	fi
 	AC_SUBST(DNF_VENDOR, [$with_dnf_vendor])
+	AC_DEFINE([__dnf_vendor_$with_dnf_vendor__], 1, [define the vendor configuration set])
 fi
 
 have_python_backend="no"


### PR DESCRIPTION
As the libgit2 module reset hack introduced in 6dc4d503cfab4c0270924ddf8acfefb4f06d47fa
is specific to Fedora and the DNF backend is used by other distributions,
it makes sense to condition the code behind the fedora vendor flag.