### PR TITLE
dnf: Fix OpenMandriva vendor for rolling variant and new architectures

### DIFF
--- a/backends/dnf/dnf-backend-vendor-openmandriva.c
+++ b/backends/dnf/dnf-backend-vendor-openmandriva.c
@@ -26,10 +26,10 @@
 gboolean
 dnf_validate_supported_repo (const gchar *id)
 {
-	guint i, j, k, l;
+	guint i, j, k, l, m;
 
 	const gchar *valid_sourcesect[] = { "",
-					  "-contrib",
+					  "-unsupported",
 					  "-restricted",
 					  "-non-free",
 					  NULL };
@@ -39,26 +39,37 @@ dnf_validate_supported_repo (const gchar *id)
 					  "-source",
 					  NULL };
 
-	const gchar *valid_arch[] = { "x86_64",
+	const gchar *valid_arch[] = { "znver1",
+				      "x86_64",
 				      "i686",
 				      "aarch64",
-				      "armv7hl",
+				      "armv7hnl",
 				      NULL };
+
+	const gchar *valid_stage[] = {  "",
+					"-updates",
+					"-testing",
+					NULL };
 
 	const gchar *valid[] = { "openmandriva",
 				 "updates",
 				 "testing",
 				 "cooker",
+				 "rolling",
+				 "rock",
+				 "release",
 				 NULL };
 
 	/* Iterate over the ID arrays to find a matching identifier */
 	for (i = 0; valid[i] != NULL; i++) {
-		for (j = 0; valid_arch[j] != NULL; j++) {
-			for (k = 0; valid_sourcesect[k] != NULL; k++) {
-				for (l = 0; valid_sourcetype[l] != NULL; l++) {
-					g_autofree gchar *source_entry = g_strconcat(valid[i], "-", valid_arch[j], valid_sourcesect[k], valid_sourcetype[l], NULL);
-					if (g_strcmp0 (id, source_entry) == 0) {
-						return TRUE;
+		for (j = 0; valid_stage[j] != NULL; j++) {
+			for (k = 0; valid_arch[k] != NULL; k++) {
+				for (l = 0; valid_sourcesect[l] != NULL; l++) {
+					for (m = 0; valid_sourcetype[m] != NULL; m++) {
+						g_autofree gchar *source_entry = g_strconcat(valid[i], valid_stage[j], "-", valid_arch[k], valid_sourcesect[l], valid_sourcetype[m], NULL);
+						if (g_strcmp0 (id, source_entry) == 0) {
+							return TRUE;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
OpenMandriva has added a rolling release variant of the distribution and
added new repos for allowing users to configure for the rock (stable),
rolling (stable beta), and cooker (devel) content.

In addition, the architectures have been slightly revised, as
an AMD Ryzen optimized variant was added and the 32-bit ARM variant
switched to armv7hnl (requiring NEON extensions).