### PR TITLE
dnf: Add vendor configuration for ROSA Linux

### DIFF
--- a/backends/dnf/Makefile.am
+++ b/backends/dnf/Makefile.am
@@ -3,7 +3,8 @@ plugin_LTLIBRARIES = libpk_backend_dnf.la
 EXTRA_DIST =								\
 	dnf-backend-vendor-fedora.c					\
 	dnf-backend-vendor-mageia.c					\
-	dnf-backend-vendor-openmandriva.c
+	dnf-backend-vendor-openmandriva.c				\
+	dnf-backend-vendor-rosa.c
 libpk_backend_dnf_la_SOURCES =						\
 	dnf-backend-vendor.h						\
 	dnf-backend.c							\

--- a/backends/dnf/dnf-backend-vendor-rosa.c
+++ b/backends/dnf/dnf-backend-vendor-rosa.c
@@ -1,0 +1,64 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2020 Neal Gompa <ngompa13@gmail.com>
+ * based on dnf-backend-vendor-mageia.c
+ *
+ * Licensed under the GNU Lesser General Public License Version 2.1
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ */
+
+#include "dnf-backend-vendor.h"
+
+gboolean
+dnf_validate_supported_repo (const gchar *id)
+{
+	guint i, j, k, l;
+
+	const gchar *valid_sourcesect[] = { "",
+					  "-contrib",
+					  "-restricted",
+					  "-non-free",
+					  NULL };
+
+	const gchar *valid_sourcetype[] = { "",
+					  "-debuginfo",
+					  "-source",
+					  NULL };
+
+	const gchar *valid_arch[] = { "x86_64",
+				      "i586",
+				      NULL };
+
+	const gchar *valid[] = { "rosa",
+				 "updates",
+				 "testing",
+				 NULL };
+
+	/* Iterate over the ID arrays to find a matching identifier */
+	for (i = 0; valid[i] != NULL; i++) {
+		for (j = 0; valid_arch[j] != NULL; j++) {
+			for (k = 0; valid_sourcesect[k] != NULL; k++) {
+				for (l = 0; valid_sourcetype[l] != NULL; l++) {
+					g_autofree gchar *source_entry = g_strconcat(valid[i], "-", valid_arch[j], valid_sourcesect[k], valid_sourcetype[l], NULL);
+					if (g_strcmp0 (id, source_entry) == 0) {
+						return TRUE;
+					}
+				}
+			}
+		}
+	}
+	return FALSE;
+}

--- a/configure.ac
+++ b/configure.ac
@@ -426,8 +426,8 @@ AC_SUBST(DBUS_SERVICES_DIR)
 if test x$enable_dnf = xyes; then
 	PKG_CHECK_MODULES(DNF, appstream-glib libdnf >= 0.22.0 rpm)
 	AC_ARG_WITH(dnf-vendor,
-			[AS_HELP_STRING([--with-dnf-vendor=<vendor>],[select a vendor configuration (fedora, mageia, openmandriva; default is fedora)])])
-	if test "$with_dnf_vendor" = "fedora" -o "$with_dnf_vendor" = "mageia" -o "$with_dnf_vendor" = "openmandriva"; then
+			[AS_HELP_STRING([--with-dnf-vendor=<vendor>],[select a vendor configuration (fedora, mageia, openmandriva, rosa; default is fedora)])])
+	if test "$with_dnf_vendor" = "fedora" -o "$with_dnf_vendor" = "mageia" -o "$with_dnf_vendor" = "openmandriva" -o "$with_dnf_vendor" = "rosa"; then
 		with_dnf_vendor="$with_dnf_vendor"
 	else
 		with_dnf_vendor="fedora"


### PR DESCRIPTION
Starting with the ROSA Linux 2019.1 platform, ROSA Linux will use
DNF as the PackageKit backend.