### PR TITLE
dnf: Load all the repos and vars directories

### DIFF
--- a/backends/dnf/meson.build
+++ b/backends/dnf/meson.build
@@ -1,5 +1,5 @@
 appstream_dep = dependency('appstream-glib')
-dnf_dep = dependency('libdnf', version: '>=0.22.0')
+dnf_dep = dependency('libdnf', version: '>=0.43.1')
 rpm_dep = dependency('rpm')
 
 shared_module(

--- a/tests/ci/Dockerfile-fedora
+++ b/tests/ci/Dockerfile-fedora
@@ -1,4 +1,4 @@
-FROM fedora:29
+FROM fedora:31
 
 RUN dnf -y update
 RUN dnf -y install dnf-plugins-core libdnf-devel redhat-rpm-config meson gcc ninja-build


### PR DESCRIPTION
Historically, the backend has internally determined its setup with
static values. However, we generally want PackageKit to load all
repositories defined in all repository directories that DNF normally
searches, since it is not guaranteed to be in `/etc/yum.repos.d` and
DNF supports multiple repository configuration paths.

We also need the vars to be loaded so that repository definitions
that rely on more than the built-in vars will work.

This bumps our dependency for libdnf to 0.43.1, as we're using APIs
introduced in this release.