### PR TITLE
alpm: Fix assertion failures for download start signals

### DIFF
--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -152,6 +152,9 @@ pk_alpm_transaction_dlcb (const gchar *basename, off_t complete, off_t total)
 	g_assert (pkalpm_current_job);
 	job = pkalpm_current_job;
 
+	/* download start signal */
+	if (total == -1) return;
+
 	g_return_if_fail (basename != NULL);
 	g_return_if_fail (complete <= total);
 


### PR DESCRIPTION
According to upstream doc [1], total being -1 is a signal for download
initialized. We should avoid giving unnecessary assertion failures for every
file download.

[1]
https://git.archlinux.org/pacman.git/tree/lib/libalpm/dload.c?id=e76ec94083235ddc5510ab57b7c2bc12a1d34e8a#n134