### PR TITLE
Meson builds for ALPM, patches

### DIFF
--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -33,9 +33,9 @@ shared_module(
   c_args: [
     '-DPK_LOG_PREFIX="PACKAGEKIT"',
     '-DG_LOG_DOMAIN="PackageKit-alpm"',
-    '-DPK_BACKEND_CONFIG_FILE="@0@"'.format(join_paths(get_option('confdir'), 'pacman.conf')),
-    '-DPK_BACKEND_GROUP_FILE="@0@"'.format(join_paths(get_option('confdir'), 'groups.list')),
-    '-DPK_BACKEND_REPO_FILE="@0@"'.format(join_paths(get_option('confdir'), 'repos.list')),
+    '-DPK_BACKEND_CONFIG_FILE="@0@"'.format(join_paths(get_option('sysconfdir'), 'pacman.conf')),
+    '-DPK_BACKEND_GROUP_FILE="@0@"'.format(join_paths(get_option('sysconfdir'), 'groups.list')),
+    '-DPK_BACKEND_REPO_FILE="@0@"'.format(join_paths(get_option('sysconfdir'), 'repos.list')),
     '-DPK_BACKEND_DEFAULT_PATH="/bin:/usr/bin:/sbin:/usr/sbin"',
   ],
   install: true,

--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -43,8 +43,8 @@ shared_module(
 )
 
 install_data(
-  'groups.list'
-  'pacman.conf'
+  'groups.list',
+  'pacman.conf',
   'repos.list',
   install_dir: join_paths(get_option('sysconfdir'), 'PackageKit', 'alpm.d')
 )

--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -1,4 +1,4 @@
-alpm_dep = dependency('libalpm', version: '>=10.0.0')
+alpm_dep = dependency('libalpm', version: '>=12.0.0')
 
 shared_module(
   'pk_backend_alpm',

--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -31,7 +31,7 @@ shared_module(
     gmodule_dep,
   ],
   c_args: [
-    '-DPK_LOG_PREFIX="PACKAGEKIT"'
+    '-DPK_LOG_PREFIX="PACKAGEKIT"',
     '-DG_LOG_DOMAIN="PackageKit-alpm"',
     '-DPK_BACKEND_CONFIG_FILE="@0@"'.format(join_paths(get_option('confdir'), 'pacman.conf')),
     '-DPK_BACKEND_GROUP_FILE="@0@"'.format(join_paths(get_option('confdir'), 'groups.list')),

--- a/backends/alpm/pk-alpm-environment.c
+++ b/backends/alpm/pk-alpm-environment.c
@@ -40,8 +40,8 @@ pk_alpm_environment_initialize (PkBackendJob *job)
 	g_setenv ("PATH", PK_BACKEND_DEFAULT_PATH, FALSE);
 
 	uname (&un);
-	value = g_strdup_printf ("%s/%s (%s %s) libalpm/%s", PACKAGE_TARNAME,
-				 PACKAGE_VERSION, un.sysname, un.machine,
+	value = g_strdup_printf ("%s/%s (%s %s) libalpm/%s", PROJECT_NAME,
+				 PROJECT_VERSION, un.sysname, un.machine,
 				 alpm_version ());
 	g_setenv ("HTTP_USER_AGENT", value, FALSE);
 	g_free (value);

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,9 @@ conf.set_quoted('DATADIR', join_paths(get_option('prefix'), get_option('datadir'
 conf.set_quoted('LIBDIR', join_paths(get_option('prefix'), get_option('libdir')))
 conf.set_quoted('SYSCONFDIR', get_option('sysconfdir'))
 
+conf.set_quoted('PROJECT_NAME', meson.project_name())
+conf.set_quoted('PROJECT_VERSION', meson.project_version())
+
 cc = meson.get_compiler('c')
 if cc.has_function('setpriority')
   conf.set('HAVE_SETPRIORITY', '1')


### PR DESCRIPTION
There are several shortcomings and errors in building ALPM using meson.

- update of the library version to the latest stable version
- changing `confdir` which does not exist in the meson configuration to`sysconfdir`.
```sh
packagekit/backends/alpm/meson.build:3:0: ERROR: Tried to access unknown option "confdir".
```
- commas were missing in several places
```sh
packagekit/backends/alpm/meson.build:35:4: ERROR: Expecting rbracket got string.
packagekit/backends/alpm/meson.build:47:2: ERROR: Expecting rparen got string.
```
- project name and version declarations were missing which were default in AC_INIT, I added appropriate constant variables.
```sh
../packagekit/backends/alpm/pk-alpm-environment.c: In function ‘pk_alpm_environment_initialize’:
../packagekit/backends/alpm/pk-alpm-environment.c:43:55: error: ‘PACKAGE_TARNAME’ undeclared (first use in this function); did you mean ‘PK_PACKAGE_ID_NAME’?
   43 |  value = g_strdup_printf ("%s/%s (%s %s) libalpm/%s", PACKAGE_TARNAME,
      |                                                       ^~~~~~~~~~~~~~~
      |                                                       PK_PACKAGE_ID_NAME
../packagekit/backends/alpm/pk-alpm-environment.c:43:55: note: each undeclared identifier is reported only once for each function it appears in

../packagekit/backends/alpm/pk-alpm-environment.c:44:6: error: ‘PACKAGE_VERSION’ undeclared (first use in this function)
   44 |      PACKAGE_VERSION, un.sysname, un.machine,
      |      ^~~~~~~~~~~~~~~
```