### PR TITLE
backends: Allow multiple backends to be built with Meson

### DIFF
--- a/backends/meson.build
+++ b/backends/meson.build
@@ -1,6 +1,11 @@
 subdir('test')
-subdir(get_option('packaging_backend'))
 
-if get_option('daemon_tests') and get_option('packaging_backend') != 'dummy'
-  subdir('dummy')
+packaging_backends = get_option('packaging_backend')
+
+if get_option('daemon_tests') and 'dummy' not in packaging_backends
+   packaging_backends += ['dummy']
 endif
+
+foreach packaging_backend : packaging_backends
+   subdir(packaging_backend)
+endforeach

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-option('packaging_backend', type : 'combo', choices : ['alpm', 'aptcc', 'dnf', 'dummy', 'entropy', 'poldek', 'portage', 'slack', 'zypp', 'nix'], value : 'dummy', description : 'The name of the backend to use')
+option('packaging_backend', type : 'array', choices : ['alpm', 'aptcc', 'dnf', 'dummy', 'entropy', 'poldek', 'portage', 'slack', 'zypp', 'nix'], value : ['dummy'], description : 'The name of the backend to use')
 option('dnf_vendor', type : 'combo', choices : ['fedora', 'mageia', 'openmandriva', 'rosa'], value : 'fedora', description : 'Vendor configuration when using the dnf backend')
 option('systemd', type : 'boolean', value : true, description : 'Use systemd and logind')
 option('systemdsystemunitdir', type : 'string', value : '', description : 'Directory for systemd service files')


### PR DESCRIPTION
PackageKit has permitted building multiple backends with Autotools,
and there's no reason to forbid this with Meson, especially as there
are still multiple options in use by some Linux distributions.

Fixes #383.