### PR TITLE
Make pk_alpm_update_database a nullop without force

### DIFF
--- a/backends/alpm/pk-alpm-update.c
+++ b/backends/alpm/pk-alpm-update.c
@@ -271,6 +271,9 @@ pk_alpm_update_database (PkBackendJob *job, gint force, alpm_db_t *db, GError **
 	if (pk_alpm_update_is_db_fresh (job, db))
 		return TRUE;
 
+	if (!force)
+		return TRUE;
+
 	result = alpm_db_update (force, db);
 	if (result > 0) {
 		dlcb ("", 1, 1);


### PR DESCRIPTION
Generally, refreshing databases without a full system update isn't desirable behaviour on systems managed by alpm and can lead to partial updates and related breakage.

Making it a nullop without force prevents the possibility of breakage in normal usage while leaving the ability for users who actually want to attempt a potentially unsafe operation to attempt it.