### PR TITLE
alpm: use separate alpm_handle_t for updates

### DIFF
--- a/backends/alpm/pk-alpm-config.h
+++ b/backends/alpm/pk-alpm-config.h
@@ -24,4 +24,4 @@
 #include <alpm.h>
 #include <glib.h>
 
-alpm_handle_t	*pk_alpm_configure	(PkBackend *backend, const gchar *filename, GError **error);
+alpm_handle_t	*pk_alpm_configure	(PkBackend *backend, const gchar *filename, gboolean is_check, GError **error);

--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -80,7 +80,7 @@ pk_alpm_initialize (PkBackend *backend, GError **error)
 {
 	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
 
-	priv->alpm = pk_alpm_configure (backend, PK_BACKEND_CONFIG_FILE, error);
+	priv->alpm = pk_alpm_configure (backend, PK_BACKEND_CONFIG_FILE, FALSE, error);
 	if (priv->alpm == NULL) {
 		g_prefix_error (error, "using %s: ", PK_BACKEND_CONFIG_FILE);
 		return FALSE;


### PR DESCRIPTION
This prevents updating the system syncdbs without updating packages,
which often leads to undesirable behaviour on most alpm-based distros.