### PR TITLE
aptcc: Add libutil to linker args

### DIFF
--- a/backends/aptcc/meson.build
+++ b/backends/aptcc/meson.build
@@ -98,6 +98,9 @@ shared_module(
     '-DDATADIR="@0@"'.format(join_paths(get_option('prefix'), get_option('datadir'))),
     ddtp_flag,
   ],
+  link_args: [
+    '-lutil',
+  ],
   override_options: ['c_std=c11', 'cpp_std=c++11'],
   install: true,
   install_dir: pk_plugin_dir,


### PR DESCRIPTION
I was getting the following error while trying to use the aptcc backend since the meson port.

```
Failed to load the backend: opening module aptcc failed : backends/aptcc/libpk_backend_aptcc.so: undefined symbol: forkpty
```

This was explicitly linked in the old Makefiles and seems to have been missed in the meson port:
https://github.com/hughsie/PackageKit/blob/3de80c8eb0dca0b57a5dbdca20e754a7de7c053a/backends/aptcc/Makefile.am#L29