### PR TITLE
alpm: synchronise syncdbs on update

### DIFF
--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -24,6 +24,7 @@ shared_module(
   'pk-alpm-transaction.c',
   'pk-alpm-transaction.h',
   'pk-alpm-update.c',
+  'pk-alpm-update.h',
   include_directories: packagekit_src_include,
   dependencies: [
     packagekit_glib2_dep,

--- a/backends/alpm/pk-alpm-sync.c
+++ b/backends/alpm/pk-alpm-sync.c
@@ -29,6 +29,7 @@
 #include "pk-alpm-databases.h"
 #include "pk-alpm-error.h"
 #include "pk-alpm-transaction.h"
+#include "pk-alpm-update.h"
 
 static gboolean
 pk_alpm_transaction_sync_targets (PkBackendJob *job, const gchar **packages, gboolean update, GError **error)
@@ -186,6 +187,13 @@ pk_backend_sync_thread (PkBackendJob* job, GVariant* params, gpointer p)
 
 	if (!only_trusted && !pk_alpm_disable_signatures (backend, &error))
 		goto out;
+
+	if ((gboolean)p) {
+		i = alpm_get_syncdbs(priv->alpm);
+		for (; i != NULL; i = i->next) {
+			pk_alpm_update_database(job, TRUE, i->data, &error);
+		}
+	}
 
 	/* download only */
 	if (pk_bitfield_contain (flags, PK_TRANSACTION_FLAG_ENUM_ONLY_DOWNLOAD))

--- a/backends/alpm/pk-alpm-update.c
+++ b/backends/alpm/pk-alpm-update.c
@@ -37,6 +37,7 @@
 #include "pk-alpm-error.h"
 #include "pk-alpm-packages.h"
 #include "pk-alpm-transaction.h"
+#include "pk-alpm-update.h"
 
 static gchar *
 pk_alpm_pkg_build_replaces (PkBackendJob *job, alpm_pkg_t *pkg)
@@ -261,7 +262,7 @@ pk_alpm_update_set_db_timestamp (alpm_db_t *db, GError **error)
 	return TRUE;
 }
 
-static gboolean
+gboolean
 pk_alpm_update_database (PkBackendJob *job, gint force, alpm_db_t *db, GError **error)
 {
 	PkBackend *backend = pk_backend_job_get_backend (job);

--- a/backends/alpm/pk-alpm-update.h
+++ b/backends/alpm/pk-alpm-update.h
@@ -1,0 +1,26 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2020 Carson Black <uhhadd@gmail.com>
+ *
+ * Licensed under the GNU General Public License Version 2
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#include <glib/gstdio.h>
+#include <alpm.h>
+#include <pk-backend.h>
+
+gboolean pk_alpm_update_database(PkBackendJob *job, gint force, alpm_db_t *db, GError **error);


### PR DESCRIPTION
Updating without synchronising databases is like `pacman -Syu` without the `pacman -Sy`:
1) It's normally not possible
2) That leaves the system in an inconsistent state