### PR TITLE
pkcon: exit with retval 5 if no packages needed be installed

### DIFF
--- a/client/pk-console.c
+++ b/client/pk-console.c
@@ -666,6 +666,7 @@ pk_console_finished_cb (GObject *object, GAsyncResult *res, gpointer data)
 		 * fatal in my book */
 		g_print ("%s: %s\n", _("Fatal error"), error->message);
 		switch (error->code - 0xff) {
+		case PK_ERROR_ENUM_ALL_PACKAGES_ALREADY_INSTALLED:
 		case PK_ERROR_ENUM_REPO_NOT_AVAILABLE:
 			ctx->retval = PK_EXIT_CODE_NOTHING_USEFUL;
 			break;


### PR DESCRIPTION
In case a user asks pkcon to install an already installed package,
so far we returned with:

  Fatal error: The packages are already all installed
  (detailed string provided by the backend)

and retval 7.

Taking pkcon's manpage into account, retval 5 is more appropriate:

RETURN VALUES
       0
           Success

       5
           Nothing useful was done.

       7
           The transaction failed, see the detailed error for more information.