### PR TITLE
Fix setting libexecdir for command-not-found helper.

### DIFF
--- a/contrib/command-not-found/meson.build
+++ b/contrib/command-not-found/meson.build
@@ -13,7 +13,7 @@ executable(
 )
 
 bashprofile_config_data = configuration_data()
-bashprofile_config_data.set('LIBEXECDIR', get_option('libexecdir'))
+bashprofile_config_data.set('LIBEXECDIR', join_paths(get_option('prefix'), get_option('libexecdir')))
 configure_file(
   input: 'PackageKit.sh.in',
   output: 'PackageKit.sh',


### PR DESCRIPTION
Otherwise you end up with `libexec/...` in `PackageKit.sh` instead of `/usr/local/libexec/...`.