### PR TITLE
test: Install required helper files

### DIFF
--- a/backends/test/helpers/meson.build
+++ b/backends/test/helpers/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  'search-name.sh',
+  install_dir: join_paths(get_option('datadir'), 'PackageKit', 'helpers', 'test_spawn'),
+)

--- a/backends/test/meson.build
+++ b/backends/test/meson.build
@@ -1,3 +1,5 @@
+subdir('helpers')
+
 shared_module(
   'pk_backend_test_fail',
   'pk-backend-test-fail.c',


### PR DESCRIPTION
During the conversion from Autotools to Meson, this part was accidentally
lost, which makes the test backend not work quite right.

This change installs the missing files for the test_spawn part of the
test backend.