### PR TITLE
Security bugs CVE-2020-16121 and aptcc specific CVE-2020-16122

### DIFF
--- a/backends/aptcc/apt-intf.cpp
+++ b/backends/aptcc/apt-intf.cpp
@@ -124,6 +124,16 @@ bool AptIntf::init(gchar **localDebs)
     // Create the AptCacheFile class to search for packages
     m_cache = new AptCacheFile(m_job);
     if (localDebs) {
+        PkBitfield flags = pk_backend_job_get_transaction_flags(m_job);
+        if (pk_bitfield_contain(flags, PK_TRANSACTION_FLAG_ENUM_ONLY_TRUSTED)) {
+            // We are NOT simulating and have untrusted packages
+            // fail the transaction.
+            pk_backend_job_error_code(m_job,
+                                  PK_ERROR_ENUM_CANNOT_INSTALL_REPO_UNSIGNED,
+                                  "Local packages cannot be authenticated");
+            return false;
+        }
+
         for (int i = 0; i < g_strv_length(localDebs); ++i) {
             markFileForInstall(localDebs[i]);
         }

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -3059,7 +3059,7 @@ pk_transaction_get_details_local (PkTransaction *transaction,
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
-				     "No such file %s", full_paths[i]);
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3070,9 +3070,8 @@ pk_transaction_get_details_local (PkTransaction *transaction,
 		if (content_type == NULL) {
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
-				     PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-				     "Failed to get content type for file %s",
-				     full_paths[i]);
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3082,9 +3081,8 @@ pk_transaction_get_details_local (PkTransaction *transaction,
 		if (!ret) {
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
-				     PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-				     "MIME type '%s' not supported %s",
-				     content_type, full_paths[i]);
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3160,7 +3158,7 @@ pk_transaction_get_files_local (PkTransaction *transaction,
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
-				     "No such file %s", full_paths[i]);
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3171,9 +3169,8 @@ pk_transaction_get_files_local (PkTransaction *transaction,
 		if (content_type == NULL) {
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
-				     PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-				     "Failed to get content type for file %s",
-				     full_paths[i]);
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3183,9 +3180,8 @@ pk_transaction_get_files_local (PkTransaction *transaction,
 		if (!ret) {
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
-				     PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-				     "MIME type '%s' not supported %s",
-				     content_type, full_paths[i]);
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 			goto out;
 		}
@@ -3688,7 +3684,7 @@ pk_transaction_install_files (PkTransaction *transaction,
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
-				     "No such file %s", full_paths[i]);
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 				goto out;
 		}
@@ -3698,9 +3694,8 @@ pk_transaction_install_files (PkTransaction *transaction,
 		if (content_type == NULL) {
 			g_set_error (&error,
 				     PK_TRANSACTION_ERROR,
-				     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
-				     "Failed to get content type for file %s",
-				     full_paths[i]);
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 				goto out;
 		}
@@ -3708,19 +3703,10 @@ pk_transaction_install_files (PkTransaction *transaction,
 		/* supported content type? */
 		ret = pk_transaction_is_supported_content_type (transaction, content_type);
 		if (!ret) {
-			if (g_strcmp0 ("application/x-app-package", content_type) == 0 ||
-			    g_str_has_suffix (full_paths[i], ".ipk") == TRUE) {
-				g_set_error (&error,
-					      PK_TRANSACTION_ERROR,
-					      PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-					      "Listaller is required to install %s", full_paths[i]);
-			} else {
-				g_set_error (&error,
-					     PK_TRANSACTION_ERROR,
-					     PK_TRANSACTION_ERROR_MIME_TYPE_NOT_SUPPORTED,
-					     "MIME type '%s' not supported %s",
-					     content_type, full_paths[i]);
-			}
+			g_set_error (&error,
+				     PK_TRANSACTION_ERROR,
+				     PK_TRANSACTION_ERROR_NO_SUCH_FILE,
+				     "File %s is not found or unsupported", full_paths[i]);
 			pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 				goto out;
 		}


### PR DESCRIPTION
Vaisha Bernard discovered that PackageKit incorrectly handled certain
methods. A local attacker could use this issue to learn the MIME type of
any file on the system. (CVE-2020-16121)

https://bugs.launchpad.net/bugs/1888887

Sami Niemimäki discovered that PackageKit incorrectly handled local deb
packages. A local user could possibly use this issue to install untrusted
packages, contrary to expectations. (CVE-2020-16122)

https://bugs.launchpad.net/bugs/1882098