### PR TITLE
main: notify the service manager when it's beginning to shutdown

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,6 +35,7 @@ if get_option('systemd')
     systemd_user_unit_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
   endif
 
+  add_project_arguments ('-DHAVE_SYSTEMD_SD_DAEMON_H=1', language: 'c')
   add_project_arguments ('-DHAVE_SYSTEMD_SD_LOGIN_H=1', language: 'c')
 else
   if get_option('offline_update')

--- a/src/pk-main.c
+++ b/src/pk-main.c
@@ -32,6 +32,9 @@
 #include <glib-unix.h>
 #include <glib/gi18n.h>
 #include <packagekit-glib2/pk-debug.h>
+#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+#include <systemd/sd-daemon.h>
+#endif
 
 #include "pk-engine.h"
 #include "pk-shared.h"
@@ -244,6 +247,10 @@ out:
 	/* log the shutdown */
 	syslog (LOG_DAEMON | LOG_DEBUG, "daemon quit");
 	closelog ();
+
+#ifdef HAVE_SYSTEMD_SD_DAEMON_H
+	sd_notify (0, "STOPPING=1");
+#endif
 
 	if (helper.timer_id > 0)
 		g_source_remove (helper.timer_id);


### PR DESCRIPTION
This makes sure that the main process won't get SIGTERM on shutdown,
for example timed exit after idling for a while. This fix the problem
that libzypp fails to clean up some temporary files when packagekitd
quits.