### PR TITLE
Rename errno to alpm_err to avoid name clashes

### DIFF
--- a/backends/alpm/pk-alpm-config.c
+++ b/backends/alpm/pk-alpm-config.c
@@ -616,7 +616,7 @@ static alpm_handle_t *
 pk_alpm_config_initialize_alpm (PkAlpmConfig *config, GError **error)
 {
 	alpm_handle_t *handle;
-	alpm_errno_t errno;
+	alpm_errno_t alpm_err;
 	gsize dir = 1;
 
 	g_return_val_if_fail (config != NULL, FALSE);
@@ -644,10 +644,10 @@ pk_alpm_config_initialize_alpm (PkAlpmConfig *config, GError **error)
 	}
 
 
-	handle = alpm_initialize (config->root, config->dbpath, &errno);
+	handle = alpm_initialize (config->root, config->dbpath, &alpm_err);
 	if (handle == NULL) {
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 		return handle;
 	}
 
@@ -658,9 +658,9 @@ pk_alpm_config_initialize_alpm (PkAlpmConfig *config, GError **error)
 	}
 
 	if (alpm_option_set_gpgdir (handle, config->gpgdir) < 0) {
-		errno = alpm_errno (handle);
-		g_set_error (error, PK_ALPM_ERROR, errno, "GPGDir: %s",
-			     alpm_strerror (errno));
+		alpm_err = alpm_errno (handle);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "GPGDir: %s",
+			     alpm_strerror (alpm_err));
 		return handle;
 	}
 
@@ -678,9 +678,9 @@ pk_alpm_config_initialize_alpm (PkAlpmConfig *config, GError **error)
 	}
 
 	if (alpm_option_set_logfile (handle, config->logfile) < 0) {
-		errno = alpm_errno (handle);
-		g_set_error (error, PK_ALPM_ERROR, errno, "LogFile: %s",
-			     alpm_strerror (errno));
+		alpm_err = alpm_errno (handle);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "LogFile: %s",
+			     alpm_strerror (alpm_err));
 		return handle;
 	}
 
@@ -693,9 +693,9 @@ pk_alpm_config_initialize_alpm (PkAlpmConfig *config, GError **error)
 
 	/* alpm takes ownership */
 	if (alpm_option_set_cachedirs (handle, config->cachedirs) < 0) {
-		errno = alpm_errno (handle);
-		g_set_error (error, PK_ALPM_ERROR, errno, "CacheDir: %s",
-			     alpm_strerror (errno));
+		alpm_err = alpm_errno (handle);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "CacheDir: %s",
+			     alpm_strerror (alpm_err));
 		return handle;
 	}
 	config->cachedirs = NULL;

--- a/backends/alpm/pk-alpm-databases.c
+++ b/backends/alpm/pk-alpm-databases.c
@@ -40,9 +40,9 @@ pk_alpm_disabled_repos_configure (PkBackend *backend, gboolean only_trusted, GEr
 	const alpm_list_t *i;
 
 	if (alpm_unregister_all_syncdbs (priv->alpm) < 0) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 		return FALSE;
 	}
 
@@ -59,9 +59,9 @@ pk_alpm_disabled_repos_configure (PkBackend *backend, gboolean only_trusted, GEr
 
 		db = alpm_register_syncdb (priv->alpm, repo->name, level);
 		if (db == NULL) {
-			alpm_errno_t errno = alpm_errno (priv->alpm);
-			g_set_error (error, PK_ALPM_ERROR, errno, "[%s]: %s",
-				     repo->name, alpm_strerror (errno));
+			alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+			g_set_error (error, PK_ALPM_ERROR, alpm_err, "[%s]: %s",
+				     repo->name, alpm_strerror (alpm_err));
 			return FALSE;
 		}
 

--- a/backends/alpm/pk-alpm-install.c
+++ b/backends/alpm/pk-alpm-install.c
@@ -62,9 +62,9 @@ pk_alpm_transaction_add_targets (PkBackendJob *job, gchar** paths, GError **erro
 
 	for (; *paths != NULL; ++paths) {
 		if (pk_alpm_install_add_file (job, *paths) < 0) {
-			alpm_errno_t errno = alpm_errno (priv->alpm);
-			g_set_error (error, PK_ALPM_ERROR, errno, "%s: %s",
-				     *paths, alpm_strerror (errno));
+			alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+			g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s: %s",
+				     *paths, alpm_strerror (alpm_err));
 			return FALSE;
 		}
 	}

--- a/backends/alpm/pk-alpm-remove.c
+++ b/backends/alpm/pk-alpm-remove.c
@@ -42,9 +42,9 @@ pk_alpm_transaction_remove_targets (PkBackendJob *job, gchar** packages, GError 
 
 		alpm_pkg_t *pkg = alpm_db_get_pkg (priv->localdb, name);
 		if (pkg == NULL || alpm_remove_pkg (priv->alpm, pkg) < 0) {
-			alpm_errno_t errno = alpm_errno (priv->alpm);
-			g_set_error (error, PK_ALPM_ERROR, errno, "%s: %s", name,
-				     alpm_strerror (errno));
+			alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+			g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s: %s", name,
+				     alpm_strerror (alpm_err));
 			return FALSE;
 		}
 	}

--- a/backends/alpm/pk-alpm-sync.c
+++ b/backends/alpm/pk-alpm-sync.c
@@ -53,9 +53,9 @@ pk_alpm_transaction_sync_targets (PkBackendJob *job, const gchar **packages, gbo
 		}
 
 		if (i == NULL) {
-			alpm_errno_t errno = ALPM_ERR_DB_NOT_FOUND;
-			g_set_error (error, PK_ALPM_ERROR, errno, "%s/%s: %s",
-				     repo, name, alpm_strerror (errno));
+			alpm_errno_t alpm_err = ALPM_ERR_DB_NOT_FOUND;
+			g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s/%s: %s",
+				     repo, name, alpm_strerror (alpm_err));
 			return FALSE;
 		}
 
@@ -76,9 +76,9 @@ pk_alpm_transaction_sync_targets (PkBackendJob *job, const gchar **packages, gbo
 		}
 
 		if (pkg == NULL || alpm_add_pkg (priv->alpm, pkg) < 0) {
-			alpm_errno_t errno = alpm_errno (priv->alpm);
-			g_set_error (error, PK_ALPM_ERROR, errno, "%s/%s: %s",
-				     repo, name, alpm_strerror (errno));
+			alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+			g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s/%s: %s",
+				     repo, name, alpm_strerror (alpm_err));
 			return FALSE;
 		}
 

--- a/backends/alpm/pk-alpm-transaction.c
+++ b/backends/alpm/pk-alpm-transaction.c
@@ -794,9 +794,9 @@ pk_alpm_transaction_initialize (PkBackendJob* job, alpm_transflag_t flags, const
 	PkBackendAlpmPrivate *priv = pk_backend_get_user_data (backend);
 
 	if (alpm_trans_init (priv->alpm, flags) < 0) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 		return FALSE;
 	}
 
@@ -995,13 +995,13 @@ pk_alpm_transaction_simulate (PkBackendJob *job, GError **error)
 	}
 
 	if (prefix != NULL) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error (error, PK_ALPM_ERROR, errno, "%s: %s", prefix,
-			     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s: %s", prefix,
+			     alpm_strerror (alpm_err));
 	} else {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 	}
 
 	return FALSE;
@@ -1105,13 +1105,13 @@ pk_alpm_transaction_commit (PkBackendJob *job, GError **error)
 	}
 
 	if (prefix != NULL) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error (error, PK_ALPM_ERROR, errno, "%s: %s", prefix,
-			     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "%s: %s", prefix,
+			     alpm_strerror (alpm_err));
 	} else {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 	}
 
 	return FALSE;
@@ -1139,9 +1139,9 @@ pk_alpm_transaction_end (PkBackendJob *job, GError **error)
 	pkalpm_current_job = NULL;
 
 	if (alpm_trans_release (priv->alpm) < 0) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error_literal (error, PK_ALPM_ERROR, errno,
-				     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error_literal (error, PK_ALPM_ERROR, alpm_err,
+				     alpm_strerror (alpm_err));
 		return FALSE;
 	}
 

--- a/backends/alpm/pk-backend-alpm.c
+++ b/backends/alpm/pk-backend-alpm.c
@@ -90,9 +90,9 @@ pk_alpm_initialize (PkBackend *backend, GError **error)
 
 	priv->localdb = alpm_get_localdb (priv->alpm);
 	if (priv->localdb == NULL) {
-		alpm_errno_t errno = alpm_errno (priv->alpm);
-		g_set_error (error, PK_ALPM_ERROR, errno, "[%s]: %s", "local",
-			     alpm_strerror (errno));
+		alpm_errno_t alpm_err = alpm_errno (priv->alpm);
+		g_set_error (error, PK_ALPM_ERROR, alpm_err, "[%s]: %s", "local",
+			     alpm_strerror (alpm_err));
 	}
 
 	return TRUE;


### PR DESCRIPTION
The current variable name `errno` results in a name clash when building the ALPM backend.
Renaming it to `alpm_err` resolved the issue.