### PR TITLE
Fix multilib conflicts in generated pk-enum-types.h

### DIFF
--- a/lib/packagekit-glib2/pk-enum-types.c.template
+++ b/lib/packagekit-glib2/pk-enum-types.c.template
@@ -9,8 +9,8 @@
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-#include "@filename@"
-/* enumerations from "@filename@" */
+#include "@basename@"
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/

--- a/lib/packagekit-glib2/pk-enum-types.h.template
+++ b/lib/packagekit-glib2/pk-enum-types.h.template
@@ -13,7 +13,7 @@ G_BEGIN_DECLS
 
 /*** BEGIN file-production ***/
 
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/


### PR DESCRIPTION
Avoid using full filename in comments as that can be different on
different arches if the build directory differs, leading to multilib
conflicts. Instead just use @basename@, which is always the same.

https://bugzilla.redhat.com/show_bug.cgi?id=1915259