### PR TITLE
alpm: Add post transaction hook

### DIFF
--- a/backends/alpm/90-packagekit-refresh.hook
+++ b/backends/alpm/90-packagekit-refresh.hook
@@ -1,0 +1,11 @@
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Operation = Remove
+Target = *
+
+[Action]
+Description = Refreshing PackageKit...
+When = PostTransaction
+Exec = /bin/sh -c 'gdbus call --system --timeout 30 --dest org.freedesktop.PackageKit --object-path /org/freedesktop/PackageKit --method org.freedesktop.PackageKit.StateHasChanged posttrans > /dev/null'

--- a/backends/alpm/meson.build
+++ b/backends/alpm/meson.build
@@ -44,6 +44,11 @@ shared_module(
 )
 
 install_data(
+  '90-packagekit-refresh.hook',
+  install_dir: join_paths(get_option('datadir'), 'libalpm', 'hooks')
+)
+
+install_data(
   'groups.list',
   'pacman.conf',
   'repos.list',


### PR DESCRIPTION
This allows refreshing the PackageKit cache after updating or installing
a package using pacman.

fixes #458