### PR TITLE
Remove large transaction size sanity check

### DIFF
--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -76,9 +76,6 @@ static gboolean pk_transaction_is_supported_content_type (PkTransaction *transac
 /* maximum number of items that can be resolved in one go */
 #define PK_TRANSACTION_MAX_ITEMS_TO_RESOLVE	10000
 
-/* maximum number of packages that can be processed in one go */
-#define PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS	10000
-
 struct PkTransactionPrivate
 {
 	PkRoleEnum		 role;
@@ -2791,18 +2788,6 @@ pk_transaction_download_packages (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
 	/* check package_ids */
 	ret = pk_package_ids_check (package_ids);
 	if (!ret) {
@@ -2901,18 +2886,6 @@ pk_transaction_depends_on (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
 	/* check package_ids */
 	ret = pk_package_ids_check (package_ids);
 	if (!ret) {
@@ -2961,18 +2934,6 @@ pk_transaction_get_details (PkTransaction *transaction,
 			     PK_TRANSACTION_ERROR,
 			     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
 			     "GetDetails not supported by backend");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -3030,21 +2991,13 @@ pk_transaction_get_details_local (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
+	/* check for empty package list */
 	length = g_strv_length (full_paths);
 	if (length == 0) {
 		g_set_error_literal (&error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
 				     "No filenames listed");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many files to process (%i/%i)", length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -3129,21 +3082,13 @@ pk_transaction_get_files_local (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
+	/* check for empty package list */
 	length = g_strv_length (full_paths);
 	if (length == 0) {
 		g_set_error_literal (&error,
 				     PK_TRANSACTION_ERROR,
 				     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
 				     "No filenames listed");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many files to process (%i/%i)", length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -3252,18 +3197,6 @@ pk_transaction_get_files (PkTransaction *transaction,
 			     PK_TRANSACTION_ERROR,
 			     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
 			     "GetFiles not supported by backend");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -3466,18 +3399,6 @@ pk_transaction_required_by (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
 	/* check package_ids */
 	ret = pk_package_ids_check (package_ids);
 	if (!ret) {
@@ -3526,18 +3447,6 @@ pk_transaction_get_update_detail (PkTransaction *transaction,
 			     PK_TRANSACTION_ERROR,
 			     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
 			     "GetUpdateDetail not supported by backend");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -3770,18 +3679,6 @@ pk_transaction_install_packages (PkTransaction *transaction,
 		goto out;
 	}
 
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
 	/* check package_ids */
 	ret = pk_package_ids_check (package_ids);
 	if (!ret) {
@@ -3965,18 +3862,6 @@ pk_transaction_remove_packages (PkTransaction *transaction,
 			     PK_TRANSACTION_ERROR,
 			     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
 			     "RemovePackages not supported by backend");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}
@@ -4655,18 +4540,6 @@ pk_transaction_update_packages (PkTransaction *transaction,
 			     PK_TRANSACTION_ERROR,
 			     PK_TRANSACTION_ERROR_NOT_SUPPORTED,
 			     "UpdatePackages not supported by backend");
-		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
-		goto out;
-	}
-
-	/* check for length sanity */
-	length = g_strv_length (package_ids);
-	if (length > PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS) {
-		g_set_error (&error,
-			     PK_TRANSACTION_ERROR,
-			     PK_TRANSACTION_ERROR_NUMBER_OF_PACKAGES_INVALID,
-			     "Too many packages to process (%i/%i)",
-			     length, PK_TRANSACTION_MAX_PACKAGES_TO_PROCESS);
 		pk_transaction_set_state (transaction, PK_TRANSACTION_STATE_ERROR);
 		goto out;
 	}


### PR DESCRIPTION
Some distros regularly push updates of tens of thousands of packages,
causing users to run into this "too many packages" error. This is not
really an error, it's just that the sanity check didn't anticipate that
the world might be insane. :) Let's remove it to avoid these issues.