### PR TITLE
Fix hangs in packagekit-glib2 client if daemon crashes

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -123,6 +123,9 @@ typedef struct {
 } PkClientState;
 
 static void
+pk_client_state_finish (PkClientState *state,
+                        const GError  *error);
+static void
 pk_client_properties_changed_cb (GDBusProxy *proxy,
 				 GVariant *changed_properties,
 				 const gchar* const  *invalidated_properties,
@@ -133,6 +136,10 @@ pk_client_signal_cb (GDBusProxy *proxy,
 		     const gchar *signal_name,
 		     GVariant *parameters,
 		     gpointer user_data);
+static void
+pk_client_notify_name_owner_cb (GObject    *obj,
+                                GParamSpec *pspec,
+                                gpointer    user_data);
 
 /**
  * pk_client_error_quark:
@@ -661,6 +668,9 @@ pk_client_state_finish (PkClientState *state, const GError *error)
 						      state);
 		g_signal_handlers_disconnect_by_func (state->proxy,
 						      G_CALLBACK (pk_client_signal_cb),
+						      state);
+		g_signal_handlers_disconnect_by_func (state->proxy,
+						      G_CALLBACK (pk_client_notify_name_owner_cb),
 						      state);
 		g_object_unref (G_OBJECT (state->proxy));
 	}
@@ -1389,6 +1399,19 @@ pk_client_signal_cb (GDBusProxy *proxy,
 		return;
 }
 
+static void
+pk_client_notify_name_owner_cb (GObject *obj,
+				GParamSpec *pspec,
+				gpointer user_data)
+{
+	PkClientState *state = (PkClientState *) user_data;
+	g_autoptr(GError) local_error = NULL;
+
+	local_error = g_error_new_literal (PK_CLIENT_ERROR, PK_CLIENT_ERROR_FAILED,
+					   "PackageKit daemon disappeared");
+	pk_client_state_finish (state, local_error);
+}
+
 /*
  * pk_client_proxy_connect:
  **/
@@ -1416,6 +1439,9 @@ pk_client_proxy_connect (PkClientState *state)
 	g_signal_connect (state->proxy, "g-signal",
 			  G_CALLBACK (pk_client_signal_cb),
 			  state);
+	g_signal_connect (state->proxy, "notify::g-name-owner",
+			  G_CALLBACK (pk_client_notify_name_owner_cb),
+			  state);
 }
 
 /*
@@ -1440,7 +1466,7 @@ pk_client_method_cb (GObject *source_object,
 		return;
 	}
 
-	/* wait for ::Finished() */
+	/* wait for ::Finished() or notify::g-name-owner (if the daemon disappears) */
 }
 
 /*
@@ -4550,6 +4576,9 @@ pk_client_get_progress_state_finish (PkClientState *state, const GError *error)
 						      state);
 		g_signal_handlers_disconnect_by_func (state->proxy,
 						      G_CALLBACK (pk_client_signal_cb),
+						      state);
+		g_signal_handlers_disconnect_by_func (state->proxy,
+						      G_CALLBACK (pk_client_notify_name_owner_cb),
 						      state);
 		g_object_unref (G_OBJECT (state->proxy));
 	}


### PR DESCRIPTION
See the commit messages for details.

This may fix https://gitlab.gnome.org/GNOME/gnome-software/-/issues/1118 (but I’m not entirely certain about it).