### PR TITLE
Fix use of POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION

### DIFF
--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4744,6 +4744,10 @@ void
 pk_client_set_locale (PkClient *client, const gchar *locale)
 {
 	g_return_if_fail (PK_IS_CLIENT (client));
+
+	if (g_strcmp0 (client->priv->locale, locale) == 0)
+		return;
+
 	client->priv->locale = g_strdup (locale);
 	g_object_notify (G_OBJECT (client), "locale");
 }
@@ -4780,6 +4784,10 @@ void
 pk_client_set_background (PkClient *client, gboolean background)
 {
 	g_return_if_fail (PK_IS_CLIENT (client));
+
+	if (client->priv->background == background)
+		return;
+
 	client->priv->background = background;
 	g_object_notify (G_OBJECT (client), "background");
 }
@@ -4815,6 +4823,10 @@ void
 pk_client_set_interactive (PkClient *client, gboolean interactive)
 {
 	g_return_if_fail (PK_IS_CLIENT (client));
+
+	if (client->priv->interactive == interactive)
+		return;
+
 	client->priv->interactive = interactive;
 	g_object_notify (G_OBJECT (client), "interactive");
 }
@@ -4866,6 +4878,10 @@ void
 pk_client_set_cache_age (PkClient *client, guint cache_age)
 {
 	g_return_if_fail (PK_IS_CLIENT (client));
+
+	if (client->priv->cache_age == cache_age)
+		return;
+
 	client->priv->cache_age = cache_age;
 	g_object_notify (G_OBJECT (client), "cache-age");
 }

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4807,7 +4807,7 @@ pk_client_get_background (PkClient *client)
  * @interactive: the value to set
  *
  * Sets the interactive value for the client. Interactive transactions
- * are usally allowed to ask the user questions.
+ * are usually allowed to ask the user questions.
  *
  * Since: 0.6.10
  **/

--- a/lib/packagekit-glib2/pk-client.c
+++ b/lib/packagekit-glib2/pk-client.c
@@ -4748,6 +4748,7 @@ pk_client_set_locale (PkClient *client, const gchar *locale)
 	if (g_strcmp0 (client->priv->locale, locale) == 0)
 		return;
 
+	g_free (client->priv->locale);
 	client->priv->locale = g_strdup (locale);
 	g_object_notify (G_OBJECT (client), "locale");
 }

--- a/src/pk-backend-spawn.c
+++ b/src/pk-backend-spawn.c
@@ -748,7 +748,6 @@ pk_backend_spawn_get_envp (PkBackendSpawn *backend_spawn)
 	g_hash_table_replace (env_table, g_strdup ("INTERACTIVE"), g_strdup (ret ? "TRUE" : "FALSE"));
 
 	/* UID */
-	ret = pk_backend_job_get_interactive (priv->job);
 	g_hash_table_replace (env_table,
 			      g_strdup ("UID"),
 			      g_strdup_printf ("%u", pk_backend_job_get_uid (priv->job)));

--- a/src/pk-engine.c
+++ b/src/pk-engine.c
@@ -632,6 +632,18 @@ pk_engine_is_proxy_unchanged (PkEngine *engine, const gchar *sender,
 	return TRUE;
 }
 
+static PolkitCheckAuthorizationFlags
+get_polkit_flags_for_dbus_invocation (GDBusMethodInvocation *invocation)
+{
+	PolkitCheckAuthorizationFlags flags = POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE;
+	GDBusMessage *message = g_dbus_method_invocation_get_message (invocation);
+
+	if (g_dbus_message_get_flags (message) & G_DBUS_MESSAGE_FLAGS_ALLOW_INTERACTIVE_AUTHORIZATION)
+		flags |= POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
+
+	return flags;
+}
+
 static void
 pk_engine_set_proxy (PkEngine *engine,
 		     const gchar *proxy_http,
@@ -715,7 +727,7 @@ pk_engine_set_proxy (PkEngine *engine,
 	polkit_authority_check_authorization (engine->priv->authority, subject,
 					      "org.freedesktop.packagekit.system-network-proxy-configure",
 					      NULL,
-					      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+					      get_polkit_flags_for_dbus_invocation (context),
 					      NULL,
 					      (GAsyncReadyCallback) pk_engine_action_obtain_proxy_authorization_finished_cb,
 					      state);
@@ -1604,7 +1616,7 @@ pk_engine_offline_method_call (GDBusConnection *connection_, const gchar *sender
 		polkit_authority_check_authorization (engine->priv->authority, subject,
 						      "org.freedesktop.packagekit.trigger-offline-update",
 						      NULL,
-						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+						      get_polkit_flags_for_dbus_invocation (invocation),
 						      NULL,
 						      pk_engine_offline_helper_cb,
 						      helper);
@@ -1618,7 +1630,7 @@ pk_engine_offline_method_call (GDBusConnection *connection_, const gchar *sender
 		polkit_authority_check_authorization (engine->priv->authority, subject,
 						      "org.freedesktop.packagekit.clear-offline-update",
 						      NULL,
-						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+						      get_polkit_flags_for_dbus_invocation (invocation),
 						      NULL,
 						      pk_engine_offline_helper_cb,
 						      helper);
@@ -1645,7 +1657,7 @@ pk_engine_offline_method_call (GDBusConnection *connection_, const gchar *sender
 		polkit_authority_check_authorization (engine->priv->authority, subject,
 						      "org.freedesktop.packagekit.trigger-offline-update",
 						      NULL,
-						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+						      get_polkit_flags_for_dbus_invocation (invocation),
 						      NULL,
 						      pk_engine_offline_helper_cb,
 						      helper);
@@ -1672,7 +1684,7 @@ pk_engine_offline_method_call (GDBusConnection *connection_, const gchar *sender
 		polkit_authority_check_authorization (engine->priv->authority, subject,
 						      "org.freedesktop.packagekit.trigger-offline-upgrade",
 						      NULL,
-						      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+						      get_polkit_flags_for_dbus_invocation (invocation),
 						      NULL,
 						      pk_engine_offline_helper_cb,
 						      helper);

--- a/src/pk-transaction.c
+++ b/src/pk-transaction.c
@@ -2256,6 +2256,7 @@ pk_transaction_authorize_actions (PkTransaction *transaction,
 	PkTransactionPrivate *priv = transaction->priv;
 	const gchar *text = NULL;
 	struct AuthorizeActionsData *data = NULL;
+	PolkitCheckAuthorizationFlags flags;
 
 	if (actions->len <= 0) {
 		g_debug ("No authentication required");
@@ -2352,13 +2353,17 @@ pk_transaction_authorize_actions (PkTransaction *transaction,
 		}
 	}
 
+	flags = POLKIT_CHECK_AUTHORIZATION_FLAGS_NONE;
+	if (pk_backend_job_get_interactive (priv->job))
+		flags |= POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION;
+
 	g_debug ("authorizing action %s", action_id);
 	/* do authorization async */
 	polkit_authority_check_authorization (priv->authority,
 					      priv->subject,
 					      action_id,
 					      details,
-					      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION,
+					      flags,
 					      priv->cancellable,
 					      (GAsyncReadyCallback) pk_transaction_authorize_actions_finished_cb,
 					      data);


### PR DESCRIPTION
PackageKit methods may be called in all sorts of contexts — as a result of an explicit user action, or as a background operation. Sometimes PackageKit will need to check a polkit action, and sometimes this will result in a polkit password prompt. Showing those prompts unexpectedly for background operations is quite surprising for users; plumb through the right D-Bus call flags and `PkTransaction` hints to try and ensure that they are only shown for PackageKit methods which are called as a result of explicit user action.

I have tested that this compiles, but no further than that.

See also:
 * https://gitlab.gnome.org/GNOME/gnome-software/-/issues/582
 * https://gitlab.gnome.org/GNOME/gnome-software/-/merge_requests/726 (this PR is complementary, but independent)